### PR TITLE
fix: add --clear to uv venv when --force is used

### DIFF
--- a/deploy/command/configure.py
+++ b/deploy/command/configure.py
@@ -103,7 +103,7 @@ def configure(  # noqa: C901
             setup_odoo_venv(executor, instance_path)
             addons_path = get_addons_path(executor, instance_path)
         elif eff_type == "python":
-            setup_python_venv(executor, instance_path)
+            setup_python_venv(executor, instance_path, force=force)
         else:  # service
             build_cmd: str | None = opts.get("build")
             if not build_cmd:

--- a/deploy/utils/venv.py
+++ b/deploy/utils/venv.py
@@ -12,9 +12,10 @@ def setup_odoo_venv(executor: Executor, instance_path: str) -> None:
     executor.run("uv pip install click-odoo-contrib", cwd=instance_path)
 
 
-def setup_python_venv(executor: Executor, instance_path: str) -> None:
+def setup_python_venv(executor: Executor, instance_path: str, force: bool = False) -> None:
     """Create a venv with ``uv`` and install dependencies from requirements.txt."""
-    executor.run("uv venv .venv", cwd=instance_path)
+    clear_flag = " --clear" if force else ""
+    executor.run(f"uv venv{clear_flag} .venv", cwd=instance_path)
     setup_python_deps(executor, instance_path)
 
 


### PR DESCRIPTION
## Summary

- Without this fix, re-running `deploy configure --force` on an existing instance fails because `uv venv` refuses to overwrite an existing `.venv` without `--clear`
- Threads the `force` flag through to `setup_python_venv` so `--clear` is only passed when needed

## Test plan

- [ ] Run `deploy configure` on a fresh instance — venv is created normally
- [ ] Run `deploy configure --force` on an existing instance — venv is recreated with `--clear`

🤖 Generated with [Claude Code](https://claude.com/claude-code)