### PR TITLE
fix: remove extra space before ellipsis in log messages

### DIFF
--- a/deploy/command/configure.py
+++ b/deploy/command/configure.py
@@ -94,7 +94,7 @@ def configure(  # noqa: C901
             raise click.ClickException(msg)
         click.secho("\nDirectory exists, skipping clone (--force).", fg="yellow")
     else:
-        click.secho(f"\nCloning {eff_repo_url} into ~/{instance_name} …", fg="green")
+        click.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
         try:
             executor.run(f"git clone {eff_repo_url} $HOME/{instance_name}")
         except ExecutorError as exc:
@@ -106,7 +106,7 @@ def configure(  # noqa: C901
     )
 
     # Step 3: Set up environment
-    click.secho(f"\nSetting up {eff_type} environment …", fg="green")
+    click.secho(f"\nSetting up {eff_type} environment…", fg="green")
     try:
         if eff_type == "odoo":
             setup_odoo_venv(executor, instance_path)
@@ -129,7 +129,7 @@ def configure(  # noqa: C901
         raise click.ClickException(click.style(str(exc), fg="red")) from exc
 
     # Step 4: Install systemd unit
-    click.secho("\nInstalling systemd unit …", fg="green")
+    click.secho("\nInstalling systemd unit…", fg="green")
     venv_path = f"{instance_path}/.venv"
 
     template_vars: dict[str, Any] = {

--- a/deploy/command/update.py
+++ b/deploy/command/update.py
@@ -115,7 +115,7 @@ def update(  # noqa: C901
         )
         raise click.ClickException(msg) from None
 
-    click.secho("\nPulling latest code …", fg="green")
+    click.secho("\nPulling latest code…", fg="green")
     try:
         executor.run("git pull", cwd=instance_path)
     except ExecutorError as exc:
@@ -125,7 +125,7 @@ def update(  # noqa: C901
         raise click.ClickException(msg) from exc
 
     # Step 6: Update dependencies / rebuild
-    click.secho("\nUpdating dependencies …", fg="green")
+    click.secho("\nUpdating dependencies…", fg="green")
     try:
         if eff_type == "odoo":
             executor.run(
@@ -146,7 +146,7 @@ def update(  # noqa: C901
         raise click.ClickException(msg) from exc
 
     # Step 7: Apply changes
-    click.secho("\nApplying changes …", fg="green")
+    click.secho("\nApplying changes…", fg="green")
     try:
         if eff_type == "odoo":
             addons_path = get_addons_path(executor, instance_path)


### PR DESCRIPTION
## Summary
- Remove inconsistent space before `…` in all log messages across `configure.py` and `update.py`

## Test plan
- [ ] Verify log output no longer has a space before the ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)