### PR TITLE
fix(update): install and use click-odoo-update in venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ On remote server where applications will be deployed:
 ```bash
 uv tool install odoo-venv
 uv tool install odoo-addons-path
-uv tool install click-odoo-contrib
 uv tool install git-aggregator
 ```
 

--- a/deploy/command/update.py
+++ b/deploy/command/update.py
@@ -151,7 +151,7 @@ def update(  # noqa: C901
         if eff_type == "odoo":
             addons_path = get_addons_path(executor, instance_path)
             executor.run(
-                f"source .venv/bin/activate && click-odoo-update -d {eff_db} --addons-path={addons_path}",
+                f".venv/bin/click-odoo-update -d {eff_db} --addons-path={addons_path}",
                 cwd=instance_path,
             )
         executor.run(f"systemctl --user restart {instance_name}")


### PR DESCRIPTION
Activating venv has no effect so we switch to installing and using click-odoo-update in venv.

Depends on https://github.com/trobz/odoo-venv/pull/86