### PR TITLE
feat: pip package deployment mode for python type

### DIFF
--- a/deploy/command/configure.py
+++ b/deploy/command/configure.py
@@ -80,11 +80,12 @@ def configure(  # noqa: C901
     eff_ssh_port: int | None = opts.get("ssh_port")
     eff_repo_url: str | None = opts.get("repo_url")
     eff_type: str = opts["type"]
-    eff_requirement: str | None = opts.get("requirement")
+    _req = opts.get("requirements")
+    eff_requirements: list[str] = ([_req] if isinstance(_req, str) else _req) if _req else []
 
-    if eff_type == "python" and eff_requirement and eff_repo_url:
+    if eff_type == "python" and eff_requirements and eff_repo_url:
         msg = click.style(
-            "requirement and repo_url are mutually exclusive for python type.",
+            "requirements and repo_url are mutually exclusive for python type.",
             fg="red",
         )
         raise click.ClickException(msg)
@@ -96,7 +97,7 @@ def configure(  # noqa: C901
     service_path = f"{instance_path}/{eff_repo_subdir}" if eff_repo_subdir else instance_path
 
     # Step 2: Set up instance directory
-    if eff_type == "python" and eff_requirement:
+    if eff_type == "python" and eff_requirements:
         # Package mode: create directory directly, no git clone
         try:
             executor.run(f"test -d {instance_path}")
@@ -148,8 +149,8 @@ def configure(  # noqa: C901
         if eff_type == "odoo":
             setup_odoo_venv(executor, instance_path)
         elif eff_type == "python":
-            if eff_requirement:
-                setup_package_venv(executor, instance_path, eff_requirement, force=force)
+            if eff_requirements:
+                setup_package_venv(executor, instance_path, eff_requirements, force=force)
             else:
                 setup_python_venv(executor, service_path, force=force)
                 executor.run(
@@ -170,7 +171,7 @@ def configure(  # noqa: C901
 
     # Step 4: Install systemd unit
     click.secho("\nInstalling systemd unit…", fg="green")
-    unit_instance_path = instance_path if eff_requirement else service_path
+    unit_instance_path = instance_path if eff_requirements else service_path
     venv_path = f"{unit_instance_path}/.venv"
 
     template_vars: dict[str, Any] = {
@@ -183,7 +184,7 @@ def configure(  # noqa: C901
         template_vars["odoo_addons_path"] = odoo_addons_path
     else:
         exec_start: str = opts.get("exec_start", "")
-        if not exec_start and not eff_requirement:
+        if not exec_start and not eff_requirements:
             res = executor.capture(
                 "if [ -f server.py ]; then echo server.py; fi",
                 cwd=service_path,

--- a/deploy/command/configure.py
+++ b/deploy/command/configure.py
@@ -7,7 +7,7 @@ import click
 from deploy.utils.config import load_config, resolve_options
 from deploy.utils.executor import Executor, ExecutorError
 from deploy.utils.render import render_unit
-from deploy.utils.venv import setup_odoo_venv, setup_python_venv
+from deploy.utils.venv import setup_odoo_venv, setup_package_venv, setup_python_venv
 
 
 def _is_git_repo(executor: Executor, path: str) -> bool:
@@ -80,10 +80,11 @@ def configure(  # noqa: C901
     eff_ssh_port: int | None = opts.get("ssh_port")
     eff_repo_url: str | None = opts.get("repo_url")
     eff_type: str = opts["type"]
+    eff_requirement: str | None = opts.get("requirement")
 
-    if not eff_repo_url:
+    if eff_type == "python" and eff_requirement and eff_repo_url:
         msg = click.style(
-            "repo_url is required. Provide it as an argument or set it in deploy.yml.",
+            "requirement and repo_url are mutually exclusive for python type.",
             fg="red",
         )
         raise click.ClickException(msg)
@@ -94,22 +95,46 @@ def configure(  # noqa: C901
     eff_repo_subdir: str | None = opts.get("repo_subdir")
     service_path = f"{instance_path}/{eff_repo_subdir}" if eff_repo_subdir else instance_path
 
-    # Step 2: Clone repository
-    if _is_git_repo(executor, instance_path):
-        if not force:
+    # Step 2: Set up instance directory
+    if eff_type == "python" and eff_requirement:
+        # Package mode: create directory directly, no git clone
+        try:
+            executor.run(f"test -d {instance_path}")
+            if not force:
+                msg = click.style(
+                    f"Instance directory already exists: ~/{instance_name}\nUse --force to re-run setup.",
+                    fg="yellow",
+                )
+                raise click.ClickException(msg)
+            click.secho("\nDirectory exists, skipping mkdir (--force).", fg="yellow")
+        except ExecutorError:
+            click.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
+            executor.run(f"mkdir -p {instance_path}")
+    else:
+        if not eff_repo_url:
             msg = click.style(
-                f"Instance directory already exists: ~/{instance_name}\nUse --force to skip cloning and re-run setup.",
-                fg="yellow",
+                "repo_url is required. Provide it as an argument or set it in deploy.yml.",
+                fg="red",
             )
             raise click.ClickException(msg)
-        click.secho("\nDirectory exists, skipping clone (--force).", fg="yellow")
-    else:
-        click.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
-        try:
-            executor.run(f"git clone {eff_repo_url} $HOME/{instance_name}")
-        except ExecutorError as exc:
-            msg = click.style(f"Git clone failed: {exc}", fg="red")
-            raise click.ClickException(msg) from exc
+
+        # Repo mode: clone
+        if _is_git_repo(executor, instance_path):
+            if not force:
+                msg = click.style(
+                    f"Instance directory already exists: ~/{instance_name}\n"
+                    "Use --force to skip cloning and re-run setup.",
+                    fg="yellow",
+                )
+                raise click.ClickException(msg)
+            click.secho("\nDirectory exists, skipping clone (--force).", fg="yellow")
+        else:
+            click.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
+            try:
+                executor.run(f"git clone {eff_repo_url} $HOME/{instance_name}")
+            except ExecutorError as exc:
+                msg = click.style(f"Git clone failed: {exc}", fg="red")
+                raise click.ClickException(msg) from exc
 
     if eff_type == "odoo":
         executor.run(
@@ -123,11 +148,14 @@ def configure(  # noqa: C901
         if eff_type == "odoo":
             setup_odoo_venv(executor, instance_path)
         elif eff_type == "python":
-            setup_python_venv(executor, service_path, force=force)
-            executor.run(
-                "if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi",
-                cwd=service_path,
-            )
+            if eff_requirement:
+                setup_package_venv(executor, instance_path, eff_requirement, force=force)
+            else:
+                setup_python_venv(executor, service_path, force=force)
+                executor.run(
+                    "if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi",
+                    cwd=service_path,
+                )
         else:  # service
             build_cmd: str | None = opts.get("build")
             if not build_cmd:
@@ -142,11 +170,12 @@ def configure(  # noqa: C901
 
     # Step 4: Install systemd unit
     click.secho("\nInstalling systemd unit…", fg="green")
-    venv_path = f"{service_path}/.venv"
+    unit_instance_path = instance_path if eff_requirement else service_path
+    venv_path = f"{unit_instance_path}/.venv"
 
     template_vars: dict[str, Any] = {
         "instance_name": instance_name,
-        "instance_path": service_path,
+        "instance_path": unit_instance_path,
     }
     if eff_type == "odoo":
         template_vars["venv_path"] = venv_path
@@ -154,7 +183,7 @@ def configure(  # noqa: C901
         template_vars["odoo_addons_path"] = odoo_addons_path
     else:
         exec_start: str = opts.get("exec_start", "")
-        if not exec_start:
+        if not exec_start and not eff_requirement:
             res = executor.capture(
                 "if [ -f server.py ]; then echo server.py; fi",
                 cwd=service_path,

--- a/deploy/command/update.py
+++ b/deploy/command/update.py
@@ -74,7 +74,8 @@ def update(  # noqa: C901
     eff_ssh_port: int | None = opts.get("ssh_port")
     eff_type: str = opts["type"]
     eff_db: str = opts.get("db", instance_name)
-    eff_requirement: str | None = opts.get("requirement")
+    _req = opts.get("requirements")
+    eff_requirements: list[str] = ([_req] if isinstance(_req, str) else _req) if _req else []
     hooks: dict = opts.get("hooks", {})
 
     executor = Executor(eff_ssh_host, ctx.obj["verbose"], ssh_port=eff_ssh_port)
@@ -117,11 +118,11 @@ def update(  # noqa: C901
     run_hooks("pre-update-success")
 
     # Step 5+6: Pull/upgrade code and update dependencies
-    if eff_type == "python" and eff_requirement:
+    if eff_type == "python" and eff_requirements:
         # Package mode: upgrade pip package directly, no git pull
         click.secho("\nUpgrading package…", fg="green")
         try:
-            upgrade_package(executor, instance_path, eff_requirement)
+            upgrade_package(executor, instance_path, eff_requirements)
         except ExecutorError as exc:
             run_hooks("post-update")
             run_hooks("post-update-fail")

--- a/deploy/command/update.py
+++ b/deploy/command/update.py
@@ -5,7 +5,7 @@ import click
 from deploy.utils.addons import get_addons_path
 from deploy.utils.config import load_config, resolve_options
 from deploy.utils.executor import Executor, ExecutorError
-from deploy.utils.venv import setup_python_deps
+from deploy.utils.venv import setup_python_deps, upgrade_package
 
 
 @click.command()
@@ -74,6 +74,7 @@ def update(  # noqa: C901
     eff_ssh_port: int | None = opts.get("ssh_port")
     eff_type: str = opts["type"]
     eff_db: str = opts.get("db", instance_name)
+    eff_requirement: str | None = opts.get("requirement")
     hooks: dict = opts.get("hooks", {})
 
     executor = Executor(eff_ssh_host, ctx.obj["verbose"], ssh_port=eff_ssh_port)
@@ -115,45 +116,56 @@ def update(  # noqa: C901
     # Step 4: pre-update-success
     run_hooks("pre-update-success")
 
-    # Step 5: git pull
-    try:
-        executor.run(f"test -d {instance_path}/.git")
-    except ExecutorError:
-        msg = click.style(
-            f"Instance directory not found or not a git repo: ~/{instance_name}",
-            fg="red",
-        )
-        raise click.ClickException(msg) from None
-
-    click.secho("\nPulling latest code…", fg="green")
-    try:
-        executor.run("git pull", cwd=instance_path)
-    except ExecutorError as exc:
-        run_hooks("post-update")
-        run_hooks("post-update-fail")
-        msg = click.style(f"git pull failed: {exc}", fg="red")
-        raise click.ClickException(msg) from exc
-
-    # Step 6: Update dependencies / rebuild
-    click.secho("\nUpdating dependencies…", fg="green")
-    try:
-        if eff_type == "odoo":
-            executor.run(
-                "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
-                cwd=instance_path,
+    # Step 5+6: Pull/upgrade code and update dependencies
+    if eff_type == "python" and eff_requirement:
+        # Package mode: upgrade pip package directly, no git pull
+        click.secho("\nUpgrading package…", fg="green")
+        try:
+            upgrade_package(executor, instance_path, eff_requirement)
+        except ExecutorError as exc:
+            run_hooks("post-update")
+            run_hooks("post-update-fail")
+            msg = click.style(f"Package upgrade failed: {exc}", fg="red")
+            raise click.ClickException(msg) from exc
+    else:
+        # Repo mode: git pull then update deps
+        try:
+            executor.run(f"test -d {instance_path}/.git")
+        except ExecutorError:
+            msg = click.style(
+                f"Instance directory not found or not a git repo: ~/{instance_name}",
+                fg="red",
             )
-            executor.run("odoo-venv update .venv --backup --yes", cwd=instance_path)
-        elif eff_type == "python":
-            setup_python_deps(executor, service_path)
-        else:  # service
-            build_cmd: str | None = opts.get("build")
-            if build_cmd:
-                executor.run(build_cmd, cwd=service_path)
-    except ExecutorError as exc:
-        run_hooks("post-update")
-        run_hooks("post-update-fail")
-        msg = click.style(f"Dependency update failed: {exc}", fg="red")
-        raise click.ClickException(msg) from exc
+            raise click.ClickException(msg) from None
+
+        click.secho("\nPulling latest code…", fg="green")
+        try:
+            executor.run("git pull", cwd=instance_path)
+        except ExecutorError as exc:
+            run_hooks("post-update")
+            run_hooks("post-update-fail")
+            msg = click.style(f"git pull failed: {exc}", fg="red")
+            raise click.ClickException(msg) from exc
+
+        click.secho("\nUpdating dependencies…", fg="green")
+        try:
+            if eff_type == "odoo":
+                executor.run(
+                    "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
+                    cwd=instance_path,
+                )
+                executor.run("odoo-venv update .venv --backup --yes", cwd=instance_path)
+            elif eff_type == "python":
+                setup_python_deps(executor, service_path)
+            else:  # service
+                build_cmd: str | None = opts.get("build")
+                if build_cmd:
+                    executor.run(build_cmd, cwd=service_path)
+        except ExecutorError as exc:
+            run_hooks("post-update")
+            run_hooks("post-update-fail")
+            msg = click.style(f"Dependency update failed: {exc}", fg="red")
+            raise click.ClickException(msg) from exc
 
     # Step 7: Apply changes
     click.secho("\nApplying changes…", fg="green")

--- a/deploy/templates/python.service.j2
+++ b/deploy/templates/python.service.j2
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory={{ instance_path }}
+EnvironmentFile=-{{ instance_path }}/.env
 ExecStart={{ venv_path }}/bin/{{ exec_start }}
 Restart=on-failure
 RestartSec=5s

--- a/deploy/utils/venv.py
+++ b/deploy/utils/venv.py
@@ -23,13 +23,13 @@ def setup_python_deps(executor: Executor, instance_path: str) -> None:
     executor.run("if [ -e pyproject.toml ]; then uv sync; fi", cwd=instance_path)
 
 
-def setup_package_venv(executor: Executor, instance_path: str, requirement: str, force: bool = False) -> None:
-    """Create a venv with ``uv`` and install a pip package directly."""
+def setup_package_venv(executor: Executor, instance_path: str, requirements: list[str], force: bool = False) -> None:
+    """Create a venv with ``uv`` and install pip packages directly."""
     clear_flag = " --clear" if force else ""
     executor.run(f"uv venv{clear_flag} .venv", cwd=instance_path)
-    executor.run(f"uv pip install {requirement}", cwd=instance_path)
+    executor.run(f"uv pip install {' '.join(requirements)}", cwd=instance_path)
 
 
-def upgrade_package(executor: Executor, instance_path: str, requirement: str) -> None:
-    """Upgrade a pip package in an existing venv."""
-    executor.run(f"uv pip install --upgrade {requirement}", cwd=instance_path)
+def upgrade_package(executor: Executor, instance_path: str, requirements: list[str]) -> None:
+    """Upgrade pip packages in an existing venv."""
+    executor.run(f"uv pip install --upgrade {' '.join(requirements)}", cwd=instance_path)

--- a/deploy/utils/venv.py
+++ b/deploy/utils/venv.py
@@ -21,3 +21,15 @@ def setup_python_venv(executor: Executor, instance_path: str, force: bool = Fals
 def setup_python_deps(executor: Executor, instance_path: str) -> None:
     executor.run("if [ -e requirements.txt ]; then uv pip install -r requirements.txt; fi", cwd=instance_path)
     executor.run("if [ -e pyproject.toml ]; then uv sync; fi", cwd=instance_path)
+
+
+def setup_package_venv(executor: Executor, instance_path: str, requirement: str, force: bool = False) -> None:
+    """Create a venv with ``uv`` and install a pip package directly."""
+    clear_flag = " --clear" if force else ""
+    executor.run(f"uv venv{clear_flag} .venv", cwd=instance_path)
+    executor.run(f"uv pip install {requirement}", cwd=instance_path)
+
+
+def upgrade_package(executor: Executor, instance_path: str, requirement: str) -> None:
+    """Upgrade a pip package in an existing venv."""
+    executor.run(f"uv pip install --upgrade {requirement}", cwd=instance_path)


### PR DESCRIPTION
## Summary

- `python` type now supports deploying directly from a pip package instead of cloning a repo — controlled by the `requirements` key in `deploy.yml`
- `requirements` and `repo_url` are mutually exclusive; a list or single string are both accepted
- `configure` creates the instance directory, sets up a venv, and runs `uv pip install`
- `update` runs `uv pip install --upgrade` instead of git pull
- `python.service.j2` now includes `EnvironmentFile=-<instance_path>/.env` so a `.env` is loaded automatically if present

## Example config

```yaml
service-myapp-production:
  type: python
  ssh_host: myserver.example.com
  requirements:
    - "myapp==1.2.3"
    - "some-dep>=2.0"
  exec_start: "myapp serve"
```

## Test plan

- [ ] `configure` with `requirements` → creates dir, venv, installs packages, registers systemd unit
- [ ] `configure` with `repo_url` → existing clone behaviour unchanged
- [ ] `configure` with both `requirements` and `repo_url` → error
- [ ] `update` with `requirements` → upgrades packages and restarts service
- [ ] `update` with `repo_url` → git pull behaviour unchanged
- [ ] Service picks up `.env` when present; starts normally when absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)