### PR TITLE
feat: add repo_branch parameter support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: Database name
     required: false
     default: ""
+  deploy_repo_branch:
+    description: Git branch to deploy (defaults to the repository's default branch)
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -84,6 +88,12 @@ runs:
       shell: bash
       run: |
         echo "  db: ${{ inputs.deploy_db }}" >> deploy.yml
+
+    - name: Append repo_branch to deploy.yml if exist
+      if: ${{ inputs.deploy_repo_branch != '' }}
+      shell: bash
+      run: |
+        echo "  repo_branch: ${{ inputs.deploy_repo_branch }}" >> deploy.yml
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/deploy/command/configure.py
+++ b/deploy/command/configure.py
@@ -50,6 +50,12 @@ def _is_git_repo(executor: Executor, path: str) -> bool:
     default=None,
     help="Subdirectory within the repo to use as the service root (for monorepos).",
 )
+@click.option(
+    "--repo-branch",
+    "repo_branch",
+    default=None,
+    help="Git branch to clone and track (defaults to the repository's default branch).",
+)
 @click.pass_context
 def configure(  # noqa: C901
     ctx: click.Context,
@@ -60,6 +66,7 @@ def configure(  # noqa: C901
     ssh_port: int | None,
     force: bool,
     repo_subdir: str | None,
+    repo_branch: str | None,
 ) -> None:
     """Configure a new deployment instance."""
     cfg = load_config(ctx.obj["config"], instance_name)
@@ -70,6 +77,7 @@ def configure(  # noqa: C901
             ssh_host=ssh_host,
             ssh_port=ssh_port,
             repo_url=repo_url,
+            repo_branch=repo_branch,
             deploy_type=deploy_type,
             repo_subdir=repo_subdir,
         )
@@ -79,6 +87,7 @@ def configure(  # noqa: C901
     eff_ssh_host: str | None = opts.get("ssh_host")
     eff_ssh_port: int | None = opts.get("ssh_port")
     eff_repo_url: str | None = opts.get("repo_url")
+    eff_repo_branch: str | None = opts.get("repo_branch")
     eff_type: str = opts["type"]
     _req = opts.get("requirements")
     eff_requirements: list[str] = ([_req] if isinstance(_req, str) else _req) if _req else []
@@ -132,7 +141,10 @@ def configure(  # noqa: C901
         else:
             click.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
             try:
-                executor.run(f"git clone {eff_repo_url} $HOME/{instance_name}")
+                clone_cmd = f"git clone {eff_repo_url} $HOME/{instance_name}"
+                if eff_repo_branch:
+                    clone_cmd += f" --branch {eff_repo_branch}"
+                executor.run(clone_cmd)
             except ExecutorError as exc:
                 msg = click.style(f"Git clone failed: {exc}", fg="red")
                 raise click.ClickException(msg) from exc

--- a/deploy/command/update.py
+++ b/deploy/command/update.py
@@ -44,6 +44,12 @@ from deploy.utils.venv import setup_python_deps, upgrade_package
     default=None,
     help="Subdirectory within the repo to use as the service root (for monorepos).",
 )
+@click.option(
+    "--repo-branch",
+    "repo_branch",
+    default=None,
+    help="Git branch to pull (defaults to the currently checked-out branch).",
+)
 @click.pass_context
 def update(  # noqa: C901
     ctx: click.Context,
@@ -54,6 +60,7 @@ def update(  # noqa: C901
     ssh_port: int | None,
     ignore_hooks: bool,
     repo_subdir: str | None,
+    repo_branch: str | None,
 ) -> None:
     """Update an existing deployment instance."""
     cfg = load_config(ctx.obj["config"], instance_name)
@@ -66,6 +73,7 @@ def update(  # noqa: C901
             deploy_type=deploy_type,
             db=db,
             repo_subdir=repo_subdir,
+            repo_branch=repo_branch,
         )
     except ValueError as exc:
         raise click.ClickException(click.style(str(exc), fg="red")) from exc
@@ -74,6 +82,7 @@ def update(  # noqa: C901
     eff_ssh_port: int | None = opts.get("ssh_port")
     eff_type: str = opts["type"]
     eff_db: str = opts.get("db", instance_name)
+    eff_repo_branch: str | None = opts.get("repo_branch")
     _req = opts.get("requirements")
     eff_requirements: list[str] = ([_req] if isinstance(_req, str) else _req) if _req else []
     hooks: dict = opts.get("hooks", {})
@@ -141,7 +150,13 @@ def update(  # noqa: C901
 
         click.secho("\nPulling latest code…", fg="green")
         try:
-            executor.run("git pull", cwd=instance_path)
+            if eff_repo_branch:
+                executor.run(
+                    f"git fetch origin && git checkout {eff_repo_branch} && git pull",
+                    cwd=instance_path,
+                )
+            else:
+                executor.run("git pull", cwd=instance_path)
         except ExecutorError as exc:
             run_hooks("post-update")
             run_hooks("post-update-fail")

--- a/deploy/utils/config.py
+++ b/deploy/utils/config.py
@@ -73,6 +73,7 @@ def resolve_options(
     ssh_host: str | None = None,
     ssh_port: int | None = None,
     repo_url: str | None = None,
+    repo_branch: str | None = None,
     deploy_type: str | None = None,
     db: str | None = None,
     repo_subdir: str | None = None,
@@ -90,6 +91,8 @@ def resolve_options(
         resolved["ssh_port"] = ssh_port
     if repo_url is not None:
         resolved["repo_url"] = repo_url
+    if repo_branch is not None:
+        resolved["repo_branch"] = repo_branch
     if deploy_type is not None:
         resolved["type"] = deploy_type
     if db is not None:


### PR DESCRIPTION
## Summary

- Add `--repo-branch` CLI option to `deploy update` and `deploy configure` commands
- Add `deploy_repo_branch` input to `action.yml` so GitHub Actions workflows can target a specific branch
- `repo_branch` can also be set in `deploy.yml` config file

## Behaviour

- **configure**: passes `--branch <branch>` to `git clone` when `repo_branch` is set
- **update**: runs `git fetch origin && git checkout <branch> && git pull` instead of bare `git pull`
- CLI flag takes precedence over `deploy.yml` config (same pattern as all other options)

## Test plan

- [x] All 22 existing tests pass (`uv run pytest`)
- [x] `deploy update --help` and `deploy configure --help` show `--repo-branch` option
- [ ] Manual test against a real server with a non-default branch

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)