### PR TITLE
fix(configure): skip venv creation when --force and venv already exists

### DIFF
--- a/trobz_deploy/command/configure.py
+++ b/trobz_deploy/command/configure.py
@@ -159,7 +159,7 @@ def configure(  # noqa: C901
     click.secho(f"\nSetting up {eff_type} environment…", fg="green")
     try:
         if eff_type == "odoo":
-            setup_odoo_venv(executor, instance_path)
+            setup_odoo_venv(executor, instance_path, force=force)
         elif eff_type == "python":
             if eff_requirements:
                 setup_package_venv(executor, instance_path, eff_requirements, force=force)

--- a/trobz_deploy/utils/venv.py
+++ b/trobz_deploy/utils/venv.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
-from trobz_deploy.utils.executor import Executor
+import click
+
+from trobz_deploy.utils.executor import Executor, ExecutorError
 
 
-def setup_odoo_venv(executor: Executor, instance_path: str) -> None:
+def _venv_exists(executor: Executor, instance_path: str) -> bool:
+    try:
+        executor.run(f"test -d {instance_path}/.venv")
+    except ExecutorError:
+        return False
+    return True
+
+
+def setup_odoo_venv(executor: Executor, instance_path: str, force: bool = False) -> None:
     """Create or update an Odoo virtual environment using ``odoo-venv``."""
+    if force and _venv_exists(executor, instance_path):
+        click.secho("Venv exists, skipping venv creation (--force).", fg="yellow")
+        return
     executor.run(
         f"odoo-venv create --project-dir {instance_path} --preset project",
         cwd=instance_path,
@@ -13,8 +26,10 @@ def setup_odoo_venv(executor: Executor, instance_path: str) -> None:
 
 def setup_python_venv(executor: Executor, instance_path: str, force: bool = False) -> None:
     """Create a venv with ``uv`` and install dependencies from requirements.txt."""
-    clear_flag = " --clear" if force else ""
-    executor.run(f"uv venv{clear_flag} .venv", cwd=instance_path)
+    if force and _venv_exists(executor, instance_path):
+        click.secho("Venv exists, skipping venv creation (--force).", fg="yellow")
+    else:
+        executor.run("uv venv .venv", cwd=instance_path)
     setup_python_deps(executor, instance_path)
 
 
@@ -25,8 +40,10 @@ def setup_python_deps(executor: Executor, instance_path: str) -> None:
 
 def setup_package_venv(executor: Executor, instance_path: str, requirements: list[str], force: bool = False) -> None:
     """Create a venv with ``uv`` and install pip packages directly."""
-    clear_flag = " --clear" if force else ""
-    executor.run(f"uv venv{clear_flag} .venv", cwd=instance_path)
+    if force and _venv_exists(executor, instance_path):
+        click.secho("Venv exists, skipping venv creation (--force).", fg="yellow")
+    else:
+        executor.run("uv venv .venv", cwd=instance_path)
     executor.run(f"uv pip install {' '.join(requirements)}", cwd=instance_path)
 
 


### PR DESCRIPTION
## Summary

- `--force` now skips venv creation (for all types: odoo, python, package) when `.venv` already exists, consistent with how it skips git clone when the repo already exists
- Adds `_venv_exists` helper and `force` parameter to `setup_odoo_venv`

## Test plan

- [ ] Run `configure <instance> --force` on an instance with an existing clone and venv — should skip both clone and venv creation with yellow warnings
- [ ] Run `configure <instance>` (no `--force`) on a fresh instance — venv is created as before
- [ ] Run `configure <instance>` (no `--force`) when instance already exists — should still error out

🤖 Generated with [Claude Code](https://claude.com/claude-code)