### PR TITLE
feat: support service type without repo or build

### DIFF
--- a/trobz_deploy/command/configure.py
+++ b/trobz_deploy/command/configure.py
@@ -120,6 +120,10 @@ def configure(  # noqa: C901
         except ExecutorError:
             click.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
             executor.run(f"mkdir -p {instance_path}")
+    elif eff_type == "service" and not eff_repo_url:
+        # Binary/system service mode: no repo, just ensure a working directory exists
+        click.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
+        executor.run(f"mkdir -p {instance_path}")
     else:
         if not eff_repo_url:
             msg = click.style(
@@ -171,13 +175,8 @@ def configure(  # noqa: C901
                 )
         else:  # service
             build_cmd: str | None = opts.get("build")
-            if not build_cmd:
-                msg = click.style(
-                    "build command is required for service type. Set it in deploy.yml.",
-                    fg="red",
-                )
-                raise click.ClickException(msg)
-            executor.run(build_cmd, cwd=service_path)
+            if build_cmd:
+                executor.run(build_cmd, cwd=service_path)
     except ExecutorError as exc:
         raise click.ClickException(click.style(str(exc), fg="red")) from exc
 

--- a/trobz_deploy/command/status.py
+++ b/trobz_deploy/command/status.py
@@ -6,6 +6,36 @@ from trobz_deploy.utils.config import load_config
 from trobz_deploy.utils.executor import Executor, ExecutorError
 
 
+def _get_unit_line(executor: Executor, instance_name: str) -> str:
+    try:
+        raw = executor.capture(
+            f"systemctl --user show {instance_name} --property=ActiveState,SubState,ActiveEnterTimestamp"
+        )
+    except ExecutorError:
+        return "unknown"
+    props: dict[str, str] = {}
+    for line in raw.splitlines():
+        if "=" in line:
+            key, _, val = line.partition("=")
+            props[key.strip()] = val.strip()
+    active = props.get("ActiveState", "unknown")
+    sub = props.get("SubState", "unknown")
+    ts = props.get("ActiveEnterTimestamp", "")
+    # Timestamp format: "Mon 2026-03-09 08:12:03 UTC"
+    since = " ".join(ts.split()[1:3]) if ts else ""
+    unit_line = f"{active} ({sub})"
+    if since:
+        unit_line += f" since {since}"
+    return unit_line
+
+
+def _get_git_info(executor: Executor, instance_path: str) -> tuple[str, str, str]:
+    remote_url = executor.capture("git remote get-url origin", cwd=instance_path)
+    branch = executor.capture("git rev-parse --abbrev-ref HEAD", cwd=instance_path)
+    commit = executor.capture("git rev-parse --short HEAD", cwd=instance_path)
+    return remote_url, branch, commit
+
+
 @click.command()
 @click.argument("instance_name")
 @click.argument("ssh_host", required=False)
@@ -49,41 +79,23 @@ def status(
         msg = f"Instance directory not found: ~/{instance_name}"
         raise click.ClickException(msg) from None
 
-    # Step 3: Git info
-    try:
-        remote_url = executor.capture("git remote get-url origin", cwd=instance_path)
-        branch = executor.capture("git rev-parse --abbrev-ref HEAD", cwd=instance_path)
-        commit = executor.capture("git rev-parse --short HEAD", cwd=instance_path)
-    except ExecutorError as exc:
-        msg = f"Failed to get git info: {exc}"
-        raise click.ClickException(msg) from exc
+    # Step 3: Git info (skipped for no-repo service instances)
+    has_repo = bool(cfg.get("repo_url"))
+    remote_url = branch = commit = None
+    if has_repo:
+        try:
+            remote_url, branch, commit = _get_git_info(executor, instance_path)
+        except ExecutorError as exc:
+            msg = f"Failed to get git info: {exc}"
+            raise click.ClickException(msg) from exc
 
     # Step 4: systemd unit status
-    unit_line = "unknown"
-    try:
-        raw = executor.capture(
-            f"systemctl --user show {instance_name} --property=ActiveState,SubState,ActiveEnterTimestamp"
-        )
-        props: dict[str, str] = {}
-        for line in raw.splitlines():
-            if "=" in line:
-                key, _, val = line.partition("=")
-                props[key.strip()] = val.strip()
-
-        active = props.get("ActiveState", "unknown")
-        sub = props.get("SubState", "unknown")
-        ts = props.get("ActiveEnterTimestamp", "")
-        # Timestamp format: "Mon 2026-03-09 08:12:03 UTC"
-        since = " ".join(ts.split()[1:3]) if ts else ""
-        unit_line = f"{active} ({sub})"
-        if since:
-            unit_line += f" since {since}"
-    except ExecutorError:
-        pass
+    unit_line = _get_unit_line(executor, instance_name)
 
     click.echo(f"Instance:  {instance_name}")
-    click.echo(f"Remote:    {remote_url}")
-    click.echo(f"Branch:    {branch} ({commit})")
+    if has_repo:
+        click.echo(f"Remote:    {remote_url}")
+        click.echo(f"Branch:    {branch} ({commit})")
     click.echo(f"Unit:      {unit_line}")
 
     if watch:

--- a/trobz_deploy/command/update.py
+++ b/trobz_deploy/command/update.py
@@ -147,6 +147,9 @@ def update(  # noqa: C901
             run_hooks("post-update-fail")
             msg = click.style(f"Package upgrade failed: {exc}", fg="red")
             raise click.ClickException(msg) from exc
+    elif eff_type == "service" and not opts.get("repo_url"):
+        # Binary/system service mode: no repo to pull, skip straight to restart
+        click.secho("\nNo repository to update, skipping pull…", fg="yellow")
     else:
         # Repo mode: git pull then update deps
         try:


### PR DESCRIPTION
## Summary

Adds support for deploying simple system-binary services (e.g. mailhog) as systemd user units without any git repository or build step. Previously, `configure` required a `repo_url` and `service` type required a `build` command; `update` and `status` would crash on such instances.

Minimal config that now works:

```yaml
mailhog-foodcoop12-staging-superquinquin:
  ssh_host: foodcoop12-stag02
  type: service
  exec_start: /usr/local/bin/mailhog -smtp-bind-addr mailhog-foodcoop12-staging-superquinquin:2025 -ui-bind-addr mailhog-foodcoop12-staging-superquinquin:9025
```

**`configure`** — when `type: service` and no `repo_url`:
- skips git clone, creates the instance directory directly (used as `WorkingDirectory`)
- `build` is now optional; runs when present, silently skipped when absent

**`update`** — when `type: service` and no `repo_url`:
- skips git pull and build entirely, goes straight to `systemctl --user restart`

**`status`** — when no `repo_url` in config:
- skips all git commands, omits `Remote` / `Branch` lines from output

Existing `service` instances with `repo_url` + `build` are unaffected.

## Test plan

- [ ] `configure` on a no-repo service creates the unit and starts it
- [ ] `update` on a no-repo service restarts the unit without git errors
- [ ] `status` on a no-repo service shows `Instance` and `Unit` lines only
- [ ] Existing repo-backed service instances still configure/update/show status correctly
- [ ] All unit tests pass (`28 passed`)