### PR TITLE
feat(configure): create Postgres role for new odoo instances

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -106,7 +106,7 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 |----------------|----------|-----------------------------------------------------------------------------------------------------|
 | `--type`       | auto     | Deployment type: `odoo`, `python`, or `service`; auto-detected from instance name prefix if omitted |
 | `-p`           | `22`     | SSH port, default 22                                                                                |
-| `--force`      | `False`  | Re-run steps 3–4 even if the instance directory already exists                                      |
+| `--force`      | `False`  | Re-run steps 3–5 even if the instance directory already exists                                      |
 | `--repo-subdir`| `None`   | Subdirectory within the repository to work on, if any                                               |
 
 **Steps (executed in order)**
@@ -117,9 +117,24 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 2. **Clone repository** — clone `repo_url` into `~/<instance_name>` on the target host.
    - If the directory already exists and is a valid Git repository:
      - Without `--force`: abort with an error and a hint to use `--force` or a different name.
-     - With `--force`: skip the clone, proceed to steps 3–4.
+     - With `--force`: skip the clone, proceed to steps 3–5.
 
-3. **Set up the application environment**
+3. **Ensure Postgres role and run gitaggregate if needed** (`odoo` only) — check whether
+   a Postgres role named `<instance_name>` already exists:
+   ```bash
+   psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='<instance_name>'" -d postgres
+   ```
+   - If it exists, do nothing.
+   - If it does not exist, create it as a superuser role and set a strong, randomly generated
+     password:
+     ```bash
+     createuser --no-createrole --superuser <instance_name>
+     psql -d postgres -c "ALTER ROLE \"<instance_name>\" WITH PASSWORD '<generated>'"
+     ```
+     The generated password is printed once to the console and is not stored anywhere by `deploy`.
+   - If there is addons/repos.yaml file, change to addons/ and run gitaggregate
+
+4. **Set up the application environment**
 
    - **`odoo`**: create a virtual environment using `odoo-venv`:
      ```bash
@@ -136,7 +151,7 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
      (e.g. `npm ci && npm run build`, `cargo build --release`), executed remotely on the target
      host. No Python venv is created.
 
-4. **Install systemd user unit** — render the appropriate bundled template, write the unit file,
+5. **Install systemd user unit** — render the appropriate bundled template, write the unit file,
    and register it with the user-level systemd instance (no `sudo` required).
 
    - Unit file destination: `~/.config/systemd/user/<instance_name>.service`
@@ -161,6 +176,7 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 | SSH connection failed (remote targets only)  | 1         |
 | Repository already exists (without `--force`)| 1         |
 | Git clone failed                   | 1         |
+| Postgres role check/creation failed (`odoo` only) | 1  |
 | Virtual environment step failed    | 1         |
 | Template rendering / write failed  | 1         |
 

--- a/tests/test_configure_postgres.py
+++ b/tests/test_configure_postgres.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from trobz_deploy.command.configure import _ensure_postgres_user, _postgres_user_exists
+from trobz_deploy.utils.executor import Executor
+
+
+def _executor() -> Any:
+    executor = Executor(None)
+    executor.capture = MagicMock()  # type: ignore[method-assign]
+    executor.run = MagicMock()  # type: ignore[method-assign]
+    return executor
+
+
+def test_postgres_user_exists_true_when_role_found():
+    executor = _executor()
+    executor.capture.return_value = "1"
+
+    assert _postgres_user_exists(executor, "odoo-foo-staging") is True
+    executor.capture.assert_called_once_with(
+        "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='odoo-foo-staging'\" -d postgres"
+    )
+
+
+def test_postgres_user_exists_false_when_role_missing():
+    executor = _executor()
+    executor.capture.return_value = ""
+
+    assert _postgres_user_exists(executor, "odoo-foo-staging") is False
+
+
+def test_ensure_postgres_user_skips_creation_when_role_exists():
+    executor = _executor()
+    executor.capture.return_value = "1"
+
+    _ensure_postgres_user(executor, "odoo-foo-staging")
+
+    executor.run.assert_not_called()
+
+
+def test_ensure_postgres_user_creates_role_with_password_when_missing(capsys):
+    executor = _executor()
+    executor.capture.return_value = ""
+
+    _ensure_postgres_user(executor, "odoo-foo-staging")
+
+    assert executor.run.call_count == 2
+    createuser_cmd, alter_role_cmd = (call.args[0] for call in executor.run.call_args_list)
+
+    assert createuser_cmd == "createuser --no-createrole --superuser odoo-foo-staging"
+    assert alter_role_cmd.startswith('psql -d postgres -c "ALTER ROLE \\"odoo-foo-staging\\" WITH PASSWORD \'')
+    assert alter_role_cmd.endswith("'\"")
+
+    out = capsys.readouterr().out
+    assert "Created Postgres user 'odoo-foo-staging' with password:" in out

--- a/trobz_deploy/command/configure.py
+++ b/trobz_deploy/command/configure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from typing import Annotated, Any
 
 import typer
@@ -17,6 +18,29 @@ def _is_git_repo(executor: Executor, path: str) -> bool:
         return False
     else:
         return True
+
+
+def _postgres_user_exists(executor: Executor, instance_name: str) -> bool:
+    result = executor.capture(
+        f"psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='{instance_name}'\" -d postgres"  # noqa: S608
+    )
+    return result.strip() == "1"
+
+
+def _ensure_postgres_user(executor: Executor, instance_name: str) -> None:
+    """Create a Postgres superuser role named after the instance, if it doesn't already exist."""
+    if _postgres_user_exists(executor, instance_name):
+        return
+
+    typer.secho(f"\nCreating Postgres user {instance_name!r}…", fg="green")
+    password = secrets.token_urlsafe(16)
+    executor.run(f"createuser --no-createrole --superuser {instance_name}")
+    executor.run(f'psql -d postgres -c "ALTER ROLE \\"{instance_name}\\" WITH PASSWORD \'{password}\'"')
+    typer.secho(
+        f"Created Postgres user {instance_name!r} with password:\n  {password}\n"
+        "Save this password now — it will not be shown again.",
+        fg="yellow",
+    )
 
 
 def configure(  # noqa: C901
@@ -126,13 +150,20 @@ def configure(  # noqa: C901
                 typer.echo(typer.style(f"Git clone failed: {exc}", fg="red"), err=True)
                 raise typer.Exit(code=1) from exc
 
+    # Step 3: Ensure Postgres role and run gitaggregate if needed
     if eff_type == "odoo":
+        try:
+            _ensure_postgres_user(executor, instance_name)
+        except ExecutorError as exc:
+            typer.echo(typer.style(str(exc), fg="red"), err=True)
+            raise typer.Exit(code=1) from exc
+
         executor.run(
             "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
             cwd=instance_path,
         )
 
-    # Step 3: Set up environment
+    # Step 4: Set up environment
     typer.secho(f"\nSetting up {eff_type} environment…", fg="green")
     try:
         if eff_type == "odoo":
@@ -154,7 +185,7 @@ def configure(  # noqa: C901
         typer.echo(typer.style(str(exc), fg="red"), err=True)
         raise typer.Exit(code=1) from exc
 
-    # Step 4: Install systemd unit
+    # Step 5: Install systemd unit
     typer.secho("\nInstalling systemd unit…", fg="green")
     unit_instance_path = instance_path if eff_requirements else service_path
     venv_path = f"{unit_instance_path}/.venv"


### PR DESCRIPTION
Adds a step that ensures a superuser Postgres role named after the instance exists before setting up the environment, generating and printing a random password when creating it. Renumbers subsequent steps in SPEC.md accordingly.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>