### PR TITLE
feat(configure,update): add --step/--except options for granular step control

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -90,7 +90,7 @@ file values, which take precedence over built-in defaults.
 **Signature**
 
 ```bash
-deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--type odoo|python|service] [-p <ssh_port>] [--force] [--repo-subdir <subdir>]
+deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--type odoo|python|service] [-p <ssh_port>] [--repo-subdir <subdir>]
 ```
 
 **Arguments**
@@ -107,7 +107,6 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 |----------------|----------|-----------------------------------------------------------------------------------------------------|
 | `--type`       | auto     | Deployment type: `odoo`, `python`, or `service`; auto-detected from instance name prefix if omitted |
 | `-p`           | `22`     | SSH port, default 22                                                                                |
-| `--force`      | `False`  | Re-run steps 3–6 even if the instance directory already exists                                      |
 | `--repo-subdir`| `None`   | Subdirectory within the repository to work on, if any                                               |
 | `--repo-branch`| `None`   | Git branch to clone and track (defaults to the repository's default branch)                        |
 | `--watch`      | `False`  | Stream service logs with journalctl after a successful configure, merge with odoo log and click-odoo-update log if applicable |
@@ -125,15 +124,14 @@ Steps 2–6 each correspond to a `--steps` / `--except` slug, shown in **bold**.
 
 2. **`set-up-instance-dir`** — set up `~/<instance_name>` on the target host:
    - **`python` with `requirements`** (package mode): create the directory with `mkdir -p`.
-     If it already exists, abort unless `--force` is given (in which case the existing
-     directory is reused).
+     If it already exists, abort with an error and a hint to use `--except dir` to skip this
+     step and reuse the existing directory.
    - **`service` without `repo_url`**: create the directory with `mkdir -p`.
    - **otherwise** (repo mode — `odoo`, `python` without `requirements`, or `service` with
      `repo_url`): clone `repo_url` into `~/<instance_name>` (`git clone --recurse-submodules`,
      optionally with `--branch <repo_branch>`).
-     - If the directory already exists and is a valid Git repository:
-       - Without `--force`: abort with an error and a hint to use `--force` or a different name.
-       - With `--force`: skip the clone, proceed to step 3.
+     - If the directory already exists and is a valid Git repository, abort with an error and a
+       hint to use `--except dir` to skip the clone and proceed to step 3.
 
 3. **`run-gitaggregate`** (`odoo` only) — if `addons/repos.yaml` exists, change to `addons/` and
    run `gitaggregate -c repos.yaml`.
@@ -176,8 +174,8 @@ Steps 2–6 each correspond to a `--steps` / `--except` slug, shown in **bold**.
      (e.g. `npm ci && npm run build`, `cargo build --release`), executed remotely on the target
      host, if any. No Python venv is created.
 
-   With `--force`, an existing `.venv` (`odoo` and `python` only) is reused instead of being
-   recreated.
+   For `odoo` and `python`, if `.venv` already exists it is reused instead of being recreated;
+   use `--except venv` to skip this step entirely.
 
 6. **`install-systemd-unit`** — render the appropriate bundled template, write the unit file,
    and register it with the user-level systemd instance (no `sudo` required).
@@ -205,7 +203,7 @@ If `--watch` is set, stream `journalctl` for the unit and merge with odoo log an
 | All requested steps succeeded                | 0         |
 | Invalid `--steps` / `--except` value         | 1         |
 | SSH connection failed (remote targets only)  | 1         |
-| Repository already exists (without `--force`)| 1         |
+| Instance directory already exists (`--except dir` not given) | 1 |
 | Git clone failed                   | 1         |
 | Postgres role check/creation failed (`odoo` only) | 1  |
 | Virtual environment / build step failed    | 1         |

--- a/SPEC.md
+++ b/SPEC.md
@@ -106,7 +106,7 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 |----------------|----------|-----------------------------------------------------------------------------------------------------|
 | `--type`       | auto     | Deployment type: `odoo`, `python`, or `service`; auto-detected from instance name prefix if omitted |
 | `-p`           | `22`     | SSH port, default 22                                                                                |
-| `--force`      | `False`  | Re-run steps 3–4 even if the instance directory already exists                                      |
+| `--force`      | `False`  | Re-run steps 3–5 even if the instance directory already exists                                      |
 | `--repo-subdir`| `None`   | Subdirectory within the repository to work on, if any                                               |
 
 **Steps (executed in order)**
@@ -117,9 +117,24 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 2. **Clone repository** — clone `repo_url` into `~/<instance_name>` on the target host.
    - If the directory already exists and is a valid Git repository:
      - Without `--force`: abort with an error and a hint to use `--force` or a different name.
-     - With `--force`: skip the clone, proceed to steps 3–4.
+     - With `--force`: skip the clone, proceed to steps 3–5.
 
-3. **Set up the application environment**
+3. **Ensure Postgres role and run gitaggregate if needed** (`odoo` only) — check whether
+   a Postgres role named `<instance_name>` already exists:
+   ```bash
+   psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='<instance_name>'" -d postgres
+   ```
+   - If it exists, do nothing.
+   - If it does not exist, create it as a superuser role and set a strong, randomly generated
+     password:
+     ```bash
+     createuser --no-createrole --superuser <instance_name>
+     psql -d postgres -c "ALTER ROLE \"<instance_name>\" WITH PASSWORD '<generated>'"
+     ```
+     The generated password is printed once to the console and is not stored anywhere by `deploy`.
+   - If there is addons/repos.yaml file, change to addons/ and run gitaggregate
+
+4. **Set up the application environment**
 
    - **`odoo`**: create a virtual environment using `odoo-venv`:
      ```bash
@@ -136,7 +151,7 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
      (e.g. `npm ci && npm run build`, `cargo build --release`), executed remotely on the target
      host. No Python venv is created.
 
-4. **Install systemd user unit** — render the appropriate bundled template, write the unit file,
+5. **Install systemd user unit** — render the appropriate bundled template, write the unit file,
    and register it with the user-level systemd instance (no `sudo` required).
 
    - Unit file destination: `~/.config/systemd/user/<instance_name>.service`
@@ -161,6 +176,7 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 | SSH connection failed (remote targets only)  | 1         |
 | Repository already exists (without `--force`)| 1         |
 | Git clone failed                   | 1         |
+| Postgres role check/creation failed (`odoo` only) | 1  |
 | Virtual environment step failed    | 1         |
 | Template rendering / write failed  | 1         |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -73,6 +73,7 @@ These options are accepted by all commands:
 
 | Option        | Default        | Description                                                    |
 |---------------|----------------|----------------------------------------------------------------|
+| `--version`   | `None`         | Print current version and exit                                |
 | `--config`    | `deploy.yml`   | Path to the configuration file (resolved locally)             |
 | `--verbose`   | `False`        | Print each remote command and its output as it runs           |
 
@@ -106,21 +107,39 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
 |----------------|----------|-----------------------------------------------------------------------------------------------------|
 | `--type`       | auto     | Deployment type: `odoo`, `python`, or `service`; auto-detected from instance name prefix if omitted |
 | `-p`           | `22`     | SSH port, default 22                                                                                |
-| `--force`      | `False`  | Re-run steps 3–5 even if the instance directory already exists                                      |
+| `--force`      | `False`  | Re-run steps 3–6 even if the instance directory already exists                                      |
 | `--repo-subdir`| `None`   | Subdirectory within the repository to work on, if any                                               |
+| `--repo-branch`| `None`   | Git branch to clone and track (defaults to the repository's default branch)                        |
+| `--watch`      | `False`  | Stream service logs with journalctl after a successful configure, merge with odoo log and click-odoo-update log if applicable |
+| `--steps`      | `all`    | Comma-separated steps to run, or `all`. See **Steps** below for available slugs                    |
+| `--except`     | `None`   | Comma-separated steps to skip (cannot be `all`). See **Steps** below for available slugs           |
 
 **Steps (executed in order)**
+
+Steps 2–6 each correspond to a `--steps` / `--except` slug, shown in **bold**. `--steps` (default
+`all`) selects which of these steps run; `--except` removes steps from that selection. Step 1
+(connecting) always runs regardless of `--steps`/`--except`.
 
 1. **Connect** — if `ssh_host` is set and is not `localhost`, open an SSH connection.
    Otherwise all subsequent commands run as local subprocesses.
 
-2. **Clone repository** — clone `repo_url` into `~/<instance_name>` on the target host.
-   - If the directory already exists and is a valid Git repository:
-     - Without `--force`: abort with an error and a hint to use `--force` or a different name.
-     - With `--force`: skip the clone, proceed to steps 3–5.
+2. **`set-up-instance-dir`** — set up `~/<instance_name>` on the target host:
+   - **`python` with `requirements`** (package mode): create the directory with `mkdir -p`.
+     If it already exists, abort unless `--force` is given (in which case the existing
+     directory is reused).
+   - **`service` without `repo_url`**: create the directory with `mkdir -p`.
+   - **otherwise** (repo mode — `odoo`, `python` without `requirements`, or `service` with
+     `repo_url`): clone `repo_url` into `~/<instance_name>` (`git clone --recurse-submodules`,
+     optionally with `--branch <repo_branch>`).
+     - If the directory already exists and is a valid Git repository:
+       - Without `--force`: abort with an error and a hint to use `--force` or a different name.
+       - With `--force`: skip the clone, proceed to step 3.
 
-3. **Ensure Postgres role and run gitaggregate if needed** (`odoo` only) — check whether
-   a Postgres role named `<instance_name>` already exists:
+3. **`run-gitaggregate`** (`odoo` only) — if `addons/repos.yaml` exists, change to `addons/` and
+   run `gitaggregate -c repos.yaml`.
+
+4. **`ensure-postgres-role`** (`odoo` only) — check whether a Postgres role named
+   `<instance_name>` already exists:
    ```bash
    psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='<instance_name>'" -d postgres
    ```
@@ -132,26 +151,35 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
      psql -d postgres -c "ALTER ROLE \"<instance_name>\" WITH PASSWORD '<generated>'"
      ```
      The generated password is printed once to the console and is not stored anywhere by `deploy`.
-   - If there is addons/repos.yaml file, change to addons/ and run gitaggregate
 
-4. **Set up the application environment**
+5. **`set-up-environment`** — set up the application environment:
 
-   - **`odoo`**: create a virtual environment using `odoo-venv`:
+   - **`odoo`**: create if not present a virtual environment using `odoo-venv`:
      ```bash
-     odoo-venv --project-dir ~/<instance_name>
+     odoo-venv create --project-dir ~/<instance_name> --preset project
      ```
-     After creation, run `odoo-addons-path` to detect and record the add-on directories.
-   - **`python`**: create a virtual environment and install dependencies using `uv`:
+   - **`python` with `requirements`** (package mode): create a venv and install the listed
+     packages directly:
+     ```bash
+     uv venv .venv
+     uv pip install <requirements...>
+     ```
+   - **`python` without `requirements`** (repo mode): create a venv and install dependencies
+     using `uv`:
      ```bash
      uv venv .venv
      if [ -e requirements.txt ]; then uv pip install -r requirements.txt; fi
      if [ -e pyproject.toml ]; then uv sync; fi
      ```
+     If `.env.example` exists and `.env` does not, copy it to `.env`.
    - **`service`**: run the `build` command defined in the local `deploy.yml`
      (e.g. `npm ci && npm run build`, `cargo build --release`), executed remotely on the target
-     host. No Python venv is created.
+     host, if any. No Python venv is created.
 
-5. **Install systemd user unit** — render the appropriate bundled template, write the unit file,
+   With `--force`, an existing `.venv` (`odoo` and `python` only) is reused instead of being
+   recreated.
+
+6. **`install-systemd-unit`** — render the appropriate bundled template, write the unit file,
    and register it with the user-level systemd instance (no `sudo` required).
 
    - Unit file destination: `~/.config/systemd/user/<instance_name>.service`
@@ -168,16 +196,19 @@ deploy [--config FILE] configure <instance_name> [<ssh_host>] [<repo_url>] [--ty
      `loginctl enable-linger` ensures the user's systemd instance (and all `--user` units) survive
      logout. It is idempotent and safe to re-run.
 
+If `--watch` is set, stream `journalctl` for the unit and merge with odoo log and click-odoo-update log if applicable after a successful run.
+
 **Exit conditions**
 
 | Condition                                    | Exit code |
 |----------------------------------------------|-----------|
-| All steps succeeded                          | 0         |
+| All requested steps succeeded                | 0         |
+| Invalid `--steps` / `--except` value         | 1         |
 | SSH connection failed (remote targets only)  | 1         |
 | Repository already exists (without `--force`)| 1         |
 | Git clone failed                   | 1         |
 | Postgres role check/creation failed (`odoo` only) | 1  |
-| Virtual environment step failed    | 1         |
+| Virtual environment / build step failed    | 1         |
 | Template rendering / write failed  | 1         |
 
 ---
@@ -203,9 +234,13 @@ deploy [--config FILE] update <instance_name> [<ssh_host>] [-p <ssh_port>] [--ty
 |--------------------|-------------------|----------------------------------------------------------|
 | `--type`           | auto              | Deployment type: `odoo`, `python`, or `service`; auto-detected from instance name prefix if omitted |
 | `-p`               | `22`              | SSH port, default 22                                     |
-| `--db`             | `<instance_name>` | (Odoo only) Override the target database name            |
+| `--db`             | `<instance_name>` | (Odoo only) Override the target database name(s). Comma-separated for multiple databases |
 | `--ignore-hooks`   | `False`           | Skip all hook execution                                  |
 | `--repo-subdir`    | `None`            | Subdirectory within the repository to work on, if any    |
+| `--repo-branch`    | `None`            | Git branch to pull (defaults to the currently checked-out branch) |
+| `--watch`          | `False`           | Stream service logs with journalctl after a successful configure, merge with odoo log and click-odoo-update log if applicable |
+| `--steps`          | `all`             | Comma-separated steps to run, or `all`. See **Steps** below for available slugs |
+| `--except`         | `None`            | Comma-separated steps to skip (cannot be `all`). See **Steps** below for available slugs |
 
 **Hooks**
 
@@ -250,51 +285,81 @@ Hook semantics:
 
 **Steps (executed in order)**
 
+Steps 5–7 each correspond to a `--steps` / `--except` slug, shown in **bold**. `--steps` (default
+`all`) selects which of these steps run; `--except` removes steps from that selection. Steps 1–4
+and 8–9 always run regardless of `--steps`/`--except`.
+
 1. **Connect** — if `ssh_host` is set and is not `localhost`, open an SSH connection.
    Otherwise all subsequent commands run as local subprocesses.
 
-2. **Run `pre-update` hooks** — execute all `pre-update` commands in order.
+2. **Run `pre-update` hooks** — execute all `pre-update` commands in order (non-blocking).
 
 3. **Run `pre-update-required` hooks** — execute in order; if any fails, run `pre-update-fail`
    hooks and abort with exit code 1.
 
 4. **Run `pre-update-success` or `pre-update-fail`** — based on the outcome of steps 2–3.
 
-5. **Pull latest code** — inside `~/<instance_name>`, run `git pull`.
-   Abort if the directory does not exist or is not a Git repository.
-
-6. **Update dependencies / rebuild**
-
-   - **`odoo`**: the script expects all changes in dependencies, even from odoo, are explicitly listed in requirements.txt, re-run `uv pip install -r requirements.txt` to sync the virtual environment.
-   - **`python`**: run `uv pip install -r requirements.txt` (if the file exists) or `uv sync` if the file pyproject.toml exists.
-   - **`service`**: re-run the `build` command from `deploy.yml`.
-
-7. **Apply changes**
-
-   - **`odoo`**: activate the virtual environment and run the upgrade, then restart the unit:
+5. **`pull-latest-code`** — behaviour depends on type:
+   - **`odoo` / `python` without `requirements` / `service` with `repo_url`** (repo mode):
+     abort if `~/<instance_name>` is not a Git repository, otherwise run
      ```bash
-     ~/<instance_name>/.venv/bin/click-odoo-upgrade -d <database_name>
-     systemctl --user restart <instance_name>
+     git pull --recurse-submodules
      ```
-   - **`python`** / **`service`**: restart the user-level systemd unit:
+     or, if `--repo-branch`/`repo_branch` is set:
      ```bash
-     systemctl --user restart <instance_name>
+     git fetch origin && git checkout <repo_branch> && git pull --recurse-submodules
      ```
+   - **`python` with `requirements`** (package mode): no-op — there is no repository to pull.
+   - **`service` without `repo_url`**: prints "No repository to update, skipping pull…" and does
+     nothing else.
 
-8. **Run `post-update` hooks**, then `post-update-success` or `post-update-fail` depending on
-   whether step 7 succeeded.
+6. **`update-dependencies`** — behaviour depends on type:
+   - **`odoo`**: re-run `gitaggregate` if `addons/repos.yaml` exists, then
+     ```bash
+     odoo-venv update .venv --backup --yes
+     ```
+   - **`python` without `requirements`** (repo mode):
+     ```bash
+     if [ -e requirements.txt ]; then uv pip install -r requirements.txt; fi
+     if [ -e pyproject.toml ]; then uv sync; fi
+     ```
+   - **`python` with `requirements`** (package mode):
+     ```bash
+     uv pip install --upgrade <requirements...>
+     ```
+   - **`service`**: re-run the `build` command from `deploy.yml`, if any.
+
+7. **`update-database`** (`odoo` only) — for each database in `--db` (comma-separated, defaults
+   to `<instance_name>`), run:
+   ```bash
+   .venv/bin/click-odoo-update --config config/odoo.conf -d <database_name> \
+       --addons-path=<addons_path> --logfile log/upgrade.log
+   ```
+
+8. **Restart** — restart the user-level systemd unit to apply changes:
+   ```bash
+   systemctl --user restart <instance_name>
+   ```
+
+9. **Run `post-update` hooks**, then `post-update-success` or `post-update-fail` depending on
+   whether step 8 succeeded.
+
+If `--watch` is set, stream `journalctl` for the unit and merge with odoo log and click-odoo-update log if applicable after a successful run.
 
 **Exit conditions**
 
 | Condition                                    | Exit code |
 |----------------------------------------------|-----------|
-| All steps succeeded                          | 0         |
+| All requested steps succeeded                | 0         |
+| Invalid `--steps` / `--except` value         | 1         |
 | SSH connection failed (remote targets only)  | 1         |
-| Instance directory not found                 | 1         |
+| Instance directory not found / not a Git repo (`pull-latest-code`, repo mode) | 1 |
 | `pre-update-required` hook failed            | 1         |
 | `git pull` failed                            | 1         |
-| Dependency update failed                     | 1         |
-| Upgrade / restart command failed             | 1         |
+| Dependency update failed (`update-dependencies`) | 1     |
+| Package upgrade failed (`update-dependencies`, `python` package mode) | 1 |
+| Database update failed (`update-database`)   | 1         |
+| Restart failed                               | 1         |
 
 ---
 

--- a/site-docs/docs/cli-reference.md
+++ b/site-docs/docs/cli-reference.md
@@ -32,6 +32,7 @@ $ deploy [OPTIONS] COMMAND [ARGS]...
 
 * `configure`: Configure a new deployment instance.
 * `update`: Update an existing deployment instance.
+* `restart`: Restart the systemd unit for a deployment...
 * `status`: Show status of a deployment instance.
 
 ## `deploy configure`
@@ -54,9 +55,11 @@ $ deploy configure [OPTIONS] INSTANCE_NAME [SSH_HOST] [REPO_URL]
 
 * `--type [odoo|python|service]`: Deployment type (auto-detected from instance name prefix if omitted).
 * `-p, --port INTEGER`: SSH port on the remote host.
-* `--force`: Re-run setup steps even if the instance directory already exists.
 * `--repo-subdir TEXT`: Subdirectory within the repo to use as the service root (for monorepos).
 * `--repo-branch TEXT`: Git branch to clone and track (defaults to the repository&#x27;s default branch).
+* `--watch`: Stream service logs with journalctl after a successful configure. Also merge with odoo and click-odoo-update logs if applicable.
+* `--steps TEXT`: Comma-separated steps to run, or &#x27;all&#x27;. Available: dir, pg, gitaggregate, venv, unit.  \[default: all\]
+* `--except TEXT`: Comma-separated steps to skip. Available: dir, pg, gitaggregate, venv, unit.
 * `--help`: Show this message and exit.
 
 ## `deploy update`
@@ -82,7 +85,31 @@ $ deploy update [OPTIONS] INSTANCE_NAME [SSH_HOST]
 * `--ignore-hooks`: Skip all hook execution.
 * `--repo-subdir TEXT`: Subdirectory within the repo to use as the service root (for monorepos).
 * `--repo-branch TEXT`: Git branch to pull (defaults to the currently checked-out branch).
-* `--watch`: Stream service logs with journalctl after a successful update.
+* `--watch`: Stream service logs with journalctl after a successful update. Also merge with odoo and click-odoo-update logs if applicable.
+* `--steps TEXT`: Comma-separated steps to run, or &#x27;all&#x27;. Available: pull, venv, db.  \[default: all\]
+* `--except TEXT`: Comma-separated steps to skip. Available: pull, venv, db.
+* `--help`: Show this message and exit.
+
+## `deploy restart`
+
+Restart the systemd unit for a deployment instance.
+
+**Usage**:
+
+```console
+$ deploy restart [OPTIONS] INSTANCE_NAME [SSH_HOST]
+```
+
+**Arguments**:
+
+* `INSTANCE_NAME`: \[required\]
+* `[SSH_HOST]`
+
+**Options**:
+
+* `--type [odoo|python|service]`: Deployment type (auto-detected from instance name prefix if omitted).
+* `-p, --port INTEGER`: SSH port on the remote host.
+* `--watch`: Stream service logs with journalctl after restarting. Also merge with odoo and click-odoo-update logs if applicable.
 * `--help`: Show this message and exit.
 
 ## `deploy status`
@@ -102,6 +129,7 @@ $ deploy status [OPTIONS] INSTANCE_NAME [SSH_HOST]
 
 **Options**:
 
+* `--type [odoo|python|service]`: Deployment type (auto-detected from instance name prefix if omitted).
 * `-p, --port INTEGER`: SSH port on the remote host.
-* `--watch`: Stream service logs with journalctl after showing status.
+* `--watch`: Stream service logs with journalctl after showing status. Also merge with odoo and click-odoo-update logs if applicable.
 * `--help`: Show this message and exit.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from trobz_deploy.utils.config import parse_instance_name
+from trobz_deploy.utils.config import parse_instance_name, parse_step_option, validate_step_slugs
 
 # ---------------------------------------------------------------------------
 # Valid names from the SPEC examples
@@ -104,3 +104,33 @@ def test_unknown_environment_raises():
 def test_error_message_lists_known_envs():
     with pytest.raises(ValueError, match="production"):
         parse_instance_name("odoo-proj-badenv")
+
+
+# ---------------------------------------------------------------------------
+# Step option parsing and validation
+# ---------------------------------------------------------------------------
+
+STEPS = {"foo": "foo", "bar": "bar", "baz": "baz"}
+
+
+def test_parse_step_option_splits_and_trims():
+    assert parse_step_option("foo, bar") == ["foo", "bar"]
+
+
+def test_parse_step_option_handles_none_and_empty():
+    assert parse_step_option(None) == []
+    assert parse_step_option("") == []
+
+
+def test_validate_step_slugs_accepts_all_when_allowed():
+    validate_step_slugs("--step", ["all"], STEPS, allow_all=True)
+
+
+def test_validate_step_slugs_rejects_all_when_not_allowed():
+    with pytest.raises(ValueError, match="Invalid --except value"):
+        validate_step_slugs("--except", ["all"], STEPS, allow_all=False)
+
+
+def test_validate_step_slugs_rejects_unknown_slug():
+    with pytest.raises(ValueError, match="Invalid --step value"):
+        validate_step_slugs("--step", ["bogus"], STEPS, allow_all=True)

--- a/tests/test_configure_postgres.py
+++ b/tests/test_configure_postgres.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from trobz_deploy.command.configure import _ensure_postgres_user, _postgres_user_exists
+from trobz_deploy.utils.executor import Executor
+
+
+def _executor() -> Any:
+    executor = Executor(None)
+    executor.capture = MagicMock()  # type: ignore[method-assign]
+    executor.run = MagicMock()  # type: ignore[method-assign]
+    return executor
+
+
+def test_postgres_user_exists_true_when_role_found():
+    executor = _executor()
+    executor.capture.return_value = "1"
+
+    assert _postgres_user_exists(executor, "odoo-foo-staging") is True
+    executor.capture.assert_called_once_with(
+        "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='odoo-foo-staging'\" -d postgres"
+    )
+
+
+def test_postgres_user_exists_false_when_role_missing():
+    executor = _executor()
+    executor.capture.return_value = ""
+
+    assert _postgres_user_exists(executor, "odoo-foo-staging") is False
+
+
+def test_ensure_postgres_user_skips_creation_when_role_exists():
+    executor = _executor()
+    executor.capture.return_value = "1"
+
+    _ensure_postgres_user(executor, "odoo-foo-staging")
+
+    executor.run.assert_not_called()
+
+
+def test_ensure_postgres_user_creates_role_with_password_when_missing(capsys):
+    executor = _executor()
+    executor.capture.return_value = ""
+
+    _ensure_postgres_user(executor, "odoo-foo-staging")
+
+    assert executor.run.call_count == 2
+    createuser_cmd, alter_role_cmd = (call.args[0] for call in executor.run.call_args_list)
+
+    assert createuser_cmd == "createuser --no-createrole --superuser odoo-foo-staging"
+    assert alter_role_cmd.startswith('psql -d postgres -c "ALTER ROLE \\"odoo-foo-staging\\" WITH PASSWORD \'')
+    assert alter_role_cmd.endswith("'\"")
+
+    out = capsys.readouterr().out
+    assert "Created Postgres user 'odoo-foo-staging' with password:" in out

--- a/tests/test_configure_steps.py
+++ b/tests/test_configure_steps.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from trobz_deploy.cli import app
+from trobz_deploy.utils.executor import ExecutorError
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _executor_mock():
+    mock = MagicMock()
+
+    def capture_side_effect(cmd, cwd=None):
+        if cmd == "echo $HOME":
+            return "/home/deploy"
+        return ""
+
+    mock.capture.side_effect = capture_side_effect
+    return mock
+
+
+def _executor_mock_fresh_dir():
+    """Executor mock where the instance directory/repo does not exist yet."""
+    mock = _executor_mock()
+
+    def run_side_effect(cmd, cwd=None, check=True):
+        if cmd.startswith("test -d"):
+            msg = "not found"
+            raise ExecutorError(msg)
+        return ""
+
+    mock.run.side_effect = run_side_effect
+    return mock
+
+
+def _invoke(
+    runner,
+    instance_name: str,
+    deploy_type: str,
+    extra_args: list[str],
+    cfg=None,
+    executor_factory=_executor_mock,
+):
+    cfg = cfg if cfg is not None else {"exec_start": "/usr/bin/myapp", "build": "make build"}
+    with (
+        patch("trobz_deploy.command.configure.Executor") as MockExecutor,
+        patch("trobz_deploy.command.configure.load_config", return_value=cfg),
+        patch("trobz_deploy.command.configure.render_unit", return_value="[Unit]\n"),
+    ):
+        mock_exec = executor_factory()
+        MockExecutor.return_value = mock_exec
+        result = runner.invoke(
+            app,
+            ["configure", instance_name, "--type", deploy_type, *extra_args],
+        )
+        return result, mock_exec
+
+
+def _run_commands(mock_exec) -> list[str]:
+    return [call.args[0] for call in mock_exec.run.call_args_list]
+
+
+def test_invalid_step_value_exits_with_error(runner):
+    result, _ = _invoke(runner, "service-myapp-production", "service", ["--steps", "bogus"])
+
+    assert result.exit_code == 1
+    assert "Invalid --steps value(s): bogus" in result.output
+
+
+def test_invalid_except_value_exits_with_error(runner):
+    result, _ = _invoke(runner, "service-myapp-production", "service", ["--except", "bogus"])
+
+    assert result.exit_code == 1
+    assert "Invalid --except value(s): bogus" in result.output
+
+
+def test_step_set_up_instance_dir_only_runs_that_step(runner):
+    result, mock_exec = _invoke(
+        runner,
+        "service-myapp-production",
+        "service",
+        ["--steps", "dir"],
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("mkdir -p" in cmd for cmd in commands)
+    assert not any("make build" in cmd for cmd in commands)
+    mock_exec.write_file.assert_not_called()
+
+
+def test_except_skips_install_systemd_unit(runner):
+    result, mock_exec = _invoke(
+        runner,
+        "service-myapp-production",
+        "service",
+        ["--except", "unit"],
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("mkdir -p" in cmd for cmd in commands)
+    assert any("make build" in cmd for cmd in commands)
+    mock_exec.write_file.assert_not_called()
+    assert not any("systemctl --user enable --now" in cmd for cmd in commands)
+
+
+def test_step_run_gitaggregate_only(runner):
+    result, mock_exec = _invoke(
+        runner,
+        "odoo-myapp-staging",
+        "odoo",
+        ["--steps", "gitaggregate"],
+        cfg={},
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("gitaggregate" in cmd for cmd in commands)
+    assert not any(cmd.startswith("createuser") for cmd in commands)
+    assert not any("odoo-venv create" in cmd for cmd in commands)
+    mock_exec.write_file.assert_not_called()
+
+
+def test_step_ensure_postgres_role_only(runner):
+    result, mock_exec = _invoke(
+        runner,
+        "odoo-myapp-staging",
+        "odoo",
+        ["--steps", "pg"],
+        cfg={},
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("gitaggregate" in cmd for cmd in commands)
+    assert any(cmd.startswith("createuser") for cmd in commands)
+    assert not any("odoo-venv create" in cmd for cmd in commands)
+    mock_exec.write_file.assert_not_called()
+
+
+def test_step_all_runs_every_step_for_odoo(runner):
+    cfg = {"repo_url": "git@example.com:org/myapp.git"}
+
+    result, mock_exec = _invoke(
+        runner,
+        "odoo-myapp-staging",
+        "odoo",
+        ["--steps", "all"],
+        cfg=cfg,
+        executor_factory=_executor_mock_fresh_dir,
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("git clone" in cmd for cmd in commands)
+    assert any(cmd.startswith("createuser") for cmd in commands)
+    assert any("gitaggregate" in cmd for cmd in commands)
+    assert any("odoo-venv create" in cmd for cmd in commands)
+    mock_exec.write_file.assert_called_once()
+    assert any("systemctl --user enable --now" in cmd for cmd in commands)
+
+
+def test_step_all_runs_every_step_for_python_package(runner):
+    cfg = {"requirements": ["mypackage"], "exec_start": "/usr/bin/myapp"}
+
+    result, mock_exec = _invoke(
+        runner,
+        "service-myapp-production",
+        "python",
+        ["--steps", "all"],
+        cfg=cfg,
+        executor_factory=_executor_mock_fresh_dir,
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("mkdir -p" in cmd for cmd in commands)
+    assert any("uv venv .venv" in cmd for cmd in commands)
+    assert any("uv pip install mypackage" in cmd for cmd in commands)
+    mock_exec.write_file.assert_called_once()
+    assert any("systemctl --user enable --now" in cmd for cmd in commands)
+
+
+def test_step_all_runs_every_step_for_service(runner):
+    result, mock_exec = _invoke(
+        runner,
+        "service-myapp-production",
+        "service",
+        [],
+    )
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("mkdir -p" in cmd for cmd in commands)
+    assert any("make build" in cmd for cmd in commands)
+    mock_exec.write_file.assert_called_once()
+    assert any("systemctl --user enable --now" in cmd for cmd in commands)

--- a/tests/test_update_steps.py
+++ b/tests/test_update_steps.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from trobz_deploy.cli import app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _executor_mock():
+    mock = MagicMock()
+
+    def capture_side_effect(cmd, cwd=None):
+        if cmd == "echo $HOME":
+            return "/home/deploy"
+        return ""
+
+    mock.capture.side_effect = capture_side_effect
+    return mock
+
+
+def _invoke(runner, instance_name: str, deploy_type: str, extra_args: list[str], cfg=None):
+    cfg = cfg if cfg is not None else {}
+    with (
+        patch("trobz_deploy.command.update.Executor") as MockExecutor,
+        patch("trobz_deploy.command.update.load_config", return_value=cfg),
+    ):
+        mock_exec = _executor_mock()
+        MockExecutor.return_value = mock_exec
+        result = runner.invoke(
+            app,
+            ["update", instance_name, "--type", deploy_type, *extra_args, "--ignore-hooks"],
+        )
+        return result, mock_exec
+
+
+def _run_commands(mock_exec) -> list[str]:
+    return [call.args[0] for call in mock_exec.run.call_args_list]
+
+
+def test_invalid_step_value_exits_with_error(runner):
+    result, _ = _invoke(runner, "odoo-myapp-staging", "odoo", ["--steps", "bogus"])
+
+    assert result.exit_code == 1
+    assert "Invalid --steps value(s): bogus" in result.output
+
+
+def test_invalid_except_value_exits_with_error(runner):
+    result, _ = _invoke(runner, "odoo-myapp-staging", "odoo", ["--except", "bogus"])
+
+    assert result.exit_code == 1
+    assert "Invalid --except value(s): bogus" in result.output
+
+
+def test_step_pull_latest_code_only(runner):
+    result, mock_exec = _invoke(runner, "odoo-myapp-staging", "odoo", ["--steps", "pull"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert any("systemctl --user restart odoo-myapp-staging" in cmd for cmd in commands)
+
+
+def test_step_update_dependencies_only(runner):
+    result, mock_exec = _invoke(runner, "odoo-myapp-staging", "odoo", ["--steps", "venv"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert any("systemctl --user restart odoo-myapp-staging" in cmd for cmd in commands)
+
+
+def test_step_update_database_only(runner):
+    result, mock_exec = _invoke(runner, "odoo-myapp-staging", "odoo", ["--steps", "db"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert any("click-odoo-update" in cmd for cmd in commands)
+    assert any("systemctl --user restart odoo-myapp-staging" in cmd for cmd in commands)
+
+
+def test_except_update_database_skips_db_update(runner):
+    result, mock_exec = _invoke(runner, "odoo-myapp-staging", "odoo", ["--except", "db"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert any("systemctl --user restart odoo-myapp-staging" in cmd for cmd in commands)
+
+
+def test_package_mode_upgrade_runs_for_dependencies_step(runner):
+    cfg = {"requirements": ["mypackage"]}
+
+    result, mock_exec = _invoke(runner, "service-myapp-production", "python", ["--steps", "venv"], cfg=cfg)
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("uv pip install --upgrade mypackage" in cmd for cmd in commands)
+
+
+def test_package_mode_upgrade_skipped_for_pull_step(runner):
+    cfg = {"requirements": ["mypackage"]}
+
+    result, mock_exec = _invoke(runner, "service-myapp-production", "python", ["--steps", "pull"], cfg=cfg)
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("uv pip install --upgrade" in cmd for cmd in commands)
+    assert any("systemctl --user restart" in cmd for cmd in commands)
+
+
+def test_package_mode_upgrade_skipped_when_only_database_step(runner):
+    cfg = {"requirements": ["mypackage"]}
+
+    result, mock_exec = _invoke(runner, "service-myapp-production", "python", ["--steps", "db"], cfg=cfg)
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("uv pip install --upgrade" in cmd for cmd in commands)
+    assert any("systemctl --user restart" in cmd for cmd in commands)
+
+
+def test_python_repo_mode_step_pull_latest_code_only(runner):
+    result, mock_exec = _invoke(runner, "service-myapp-production", "python", ["--steps", "pull"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert not any("uv sync" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)
+
+
+def test_python_repo_mode_step_update_dependencies_only(runner):
+    result, mock_exec = _invoke(runner, "service-myapp-production", "python", ["--steps", "venv"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert any("uv sync" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)
+
+
+def test_python_repo_mode_update_database_step_is_noop(runner):
+    result, mock_exec = _invoke(runner, "service-myapp-production", "python", ["--steps", "db"])
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert not any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert not any("uv sync" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)
+
+
+def test_service_repo_mode_step_pull_latest_code_only(runner):
+    cfg = {"repo_url": "git@example.com:org/myapp.git", "build": "make build"}
+
+    result, mock_exec = _invoke(runner, "service-myapp-production", "service", ["--steps", "pull"], cfg=cfg)
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert not any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert not any("make build" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)
+
+
+def test_service_repo_mode_step_update_dependencies_only(runner):
+    cfg = {"repo_url": "git@example.com:org/myapp.git", "build": "make build"}
+
+    result, mock_exec = _invoke(runner, "service-myapp-production", "service", ["--steps", "venv"], cfg=cfg)
+
+    assert result.exit_code == 0
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert not any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert any("make build" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)
+
+
+def test_service_no_repo_default_steps_prints_skip_message(runner):
+    result, mock_exec = _invoke(runner, "service-myapp-production", "service", [])
+
+    assert result.exit_code == 0
+    assert "No repository to update, skipping pull" in result.output
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert not any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert not any("make build" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)
+
+
+def test_service_no_repo_step_update_dependencies_skips_pull_message(runner):
+    result, mock_exec = _invoke(runner, "service-myapp-production", "service", ["--steps", "venv"])
+
+    assert result.exit_code == 0
+    assert "No repository to update, skipping pull" not in result.output
+    commands = _run_commands(mock_exec)
+    assert not any("git pull --recurse-submodules" in cmd for cmd in commands)
+    assert not any("odoo-venv update" in cmd for cmd in commands)
+    assert not any("click-odoo-update" in cmd for cmd in commands)
+    assert not any("uv pip install -r requirements.txt" in cmd for cmd in commands)
+    assert not any("make build" in cmd for cmd in commands)
+    assert any("systemctl --user restart service-myapp-production" in cmd for cmd in commands)

--- a/trobz_deploy/command/configure.py
+++ b/trobz_deploy/command/configure.py
@@ -62,10 +62,6 @@ def configure(  # noqa: C901
         typer.Option("--type", help="Deployment type (auto-detected from instance name prefix if omitted)."),
     ] = None,
     ssh_port: Annotated[int | None, typer.Option("-p", "--port", help="SSH port on the remote host.")] = None,
-    force: Annotated[
-        bool,
-        typer.Option("--force", help="Re-run setup steps even if the instance directory already exists."),
-    ] = False,
     repo_subdir: Annotated[
         str | None,
         typer.Option(help="Subdirectory within the repo to use as the service root (for monorepos)."),
@@ -76,7 +72,13 @@ def configure(  # noqa: C901
     ] = None,
     watch: Annotated[
         bool,
-        typer.Option("--watch", help="Stream service logs with journalctl after a successful configure."),
+        typer.Option(
+            "--watch",
+            help=(
+                "Stream service logs with journalctl after a successful configure. "
+                "Also merge with odoo and click-odoo-update logs if applicable."
+            ),
+        ),
     ] = False,
     steps: Annotated[
         str,
@@ -147,11 +149,9 @@ def configure(  # noqa: C901
             # Package mode: create directory directly, no git clone
             try:
                 executor.run(f"test -d {instance_path}")
-                if not force:
-                    msg = f"Instance directory already exists: ~/{instance_name}\nUse --force to re-run setup."
-                    typer.echo(typer.style(msg, fg="yellow"), err=True)
-                    raise typer.Exit(code=1)
-                typer.secho("\nDirectory exists, skipping mkdir (--force).", fg="yellow")
+                msg = f"Instance directory already exists: ~/{instance_name}\nUse --except dir to skip this step."
+                typer.echo(typer.style(msg, fg="yellow"), err=True)
+                raise typer.Exit(code=1)
             except ExecutorError:
                 typer.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
                 executor.run(f"mkdir -p {instance_path}")
@@ -167,24 +167,19 @@ def configure(  # noqa: C901
 
             # Repo mode: clone
             if _is_git_repo(executor, instance_path):
-                if not force:
-                    msg = (
-                        f"Instance directory already exists: ~/{instance_name}\n"
-                        "Use --force to skip cloning and re-run setup."
-                    )
-                    typer.echo(typer.style(msg, fg="yellow"), err=True)
-                    raise typer.Exit(code=1)
-                typer.secho("\nDirectory exists, skipping clone (--force).", fg="yellow")
-            else:
-                typer.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
-                try:
-                    clone_cmd = f"git clone --recurse-submodules {eff_repo_url} $HOME/{instance_name}"
-                    if eff_repo_branch:
-                        clone_cmd += f" --branch {eff_repo_branch}"
-                    executor.run(clone_cmd)
-                except ExecutorError as exc:
-                    typer.echo(typer.style(f"Git clone failed: {exc}", fg="red"), err=True)
-                    raise typer.Exit(code=1) from exc
+                msg = f"Instance directory already exists: ~/{instance_name}\nUse --except dir to skip this step."
+                typer.echo(typer.style(msg, fg="yellow"), err=True)
+                raise typer.Exit(code=1)
+
+            typer.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
+            try:
+                clone_cmd = f"git clone --recurse-submodules {eff_repo_url} $HOME/{instance_name}"
+                if eff_repo_branch:
+                    clone_cmd += f" --branch {eff_repo_branch}"
+                executor.run(clone_cmd)
+            except ExecutorError as exc:
+                typer.echo(typer.style(f"Git clone failed: {exc}", fg="red"), err=True)
+                raise typer.Exit(code=1) from exc
 
     # Step 3: Run gitaggregate if needed
     if eff_type == "odoo" and _run_step("gitaggregate"):
@@ -206,12 +201,12 @@ def configure(  # noqa: C901
         typer.secho(f"\nSetting up {eff_type} environment…", fg="green")
         try:
             if eff_type == "odoo":
-                setup_odoo_venv(executor, instance_path, force=force)
+                setup_odoo_venv(executor, instance_path)
             elif eff_type == "python":
                 if eff_requirements:
-                    setup_package_venv(executor, instance_path, eff_requirements, force=force)
+                    setup_package_venv(executor, instance_path, eff_requirements)
                 else:
-                    setup_python_venv(executor, service_path, force=force)
+                    setup_python_venv(executor, service_path)
                     executor.run(
                         "if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi",
                         cwd=service_path,

--- a/trobz_deploy/command/configure.py
+++ b/trobz_deploy/command/configure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from typing import Annotated, Any
 
 import typer
@@ -17,6 +18,29 @@ def _is_git_repo(executor: Executor, path: str) -> bool:
         return False
     else:
         return True
+
+
+def _postgres_user_exists(executor: Executor, instance_name: str) -> bool:
+    result = executor.capture(
+        f"psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='{instance_name}'\" -d postgres"  # noqa: S608
+    )
+    return result.strip() == "1"
+
+
+def _ensure_postgres_user(executor: Executor, instance_name: str) -> None:
+    """Create a Postgres superuser role named after the instance, if it doesn't already exist."""
+    if _postgres_user_exists(executor, instance_name):
+        return
+
+    typer.secho(f"\nCreating Postgres user {instance_name!r}…", fg="green")
+    password = secrets.token_urlsafe(16)
+    executor.run(f"createuser --no-createrole --superuser {instance_name}")
+    executor.run(f'psql -d postgres -c "ALTER ROLE \\"{instance_name}\\" WITH PASSWORD \'{password}\'"')
+    typer.secho(
+        f"Created Postgres user {instance_name!r} with password:\n  {password}\n"
+        "Save this password now — it will not be shown again.",
+        fg="yellow",
+    )
 
 
 def configure(  # noqa: C901
@@ -126,13 +150,20 @@ def configure(  # noqa: C901
                 typer.echo(typer.style(f"Git clone failed: {exc}", fg="red"), err=True)
                 raise typer.Exit(code=1) from exc
 
+    # Step 3: Ensure Postgres role and run gitaggregate if needed
     if eff_type == "odoo":
+        try:
+            _ensure_postgres_user(executor, instance_name)
+        except ExecutorError as exc:
+            typer.echo(typer.style(str(exc), fg="red"), err=True)
+            raise typer.Exit(code=1) from exc
+
         executor.run(
             "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
             cwd=instance_path,
         )
 
-    # Step 3: Set up environment
+    # Step 4: Set up environment
     typer.secho(f"\nSetting up {eff_type} environment…", fg="green")
     try:
         if eff_type == "odoo":
@@ -154,7 +185,7 @@ def configure(  # noqa: C901
         typer.echo(typer.style(str(exc), fg="red"), err=True)
         raise typer.Exit(code=1) from exc
 
-    # Step 4: Install systemd unit
+    # Step 5: Install systemd unit
     typer.secho("\nInstalling systemd unit…", fg="green")
     unit_instance_path = instance_path if eff_requirements else service_path
     venv_path = f"{unit_instance_path}/.venv"

--- a/trobz_deploy/command/configure.py
+++ b/trobz_deploy/command/configure.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 
 import typer
 
-from trobz_deploy.utils.config import DeployType, load_config, resolve_options
+from trobz_deploy.utils.config import DeployType, load_config, parse_step_option, resolve_options, validate_step_slugs
 from trobz_deploy.utils.executor import Executor, ExecutorError
 from trobz_deploy.utils.render import render_unit
 from trobz_deploy.utils.venv import setup_odoo_venv, setup_package_venv, setup_python_venv
@@ -43,6 +43,15 @@ def _ensure_postgres_user(executor: Executor, instance_name: str) -> None:
     )
 
 
+CONFIGURE_STEPS = {
+    "dir": "Setting up instance directory",
+    "pg": "Ensure postgres role exists",
+    "gitaggregate": "Run gitaggregate if needed",
+    "venv": "Creating the venv",
+    "unit": "Installing systemd unit",
+}
+
+
 def configure(  # noqa: C901
     ctx: typer.Context,
     instance_name: Annotated[str, typer.Argument()],
@@ -69,8 +78,34 @@ def configure(  # noqa: C901
         bool,
         typer.Option("--watch", help="Stream service logs with journalctl after a successful configure."),
     ] = False,
+    steps: Annotated[
+        str,
+        typer.Option(
+            "--steps",
+            help=f"Comma-separated steps to run, or 'all'. Available: {', '.join(CONFIGURE_STEPS.keys())}.",
+        ),
+    ] = "all",
+    skip_steps: Annotated[
+        str | None,
+        typer.Option(
+            "--except",
+            help=f"Comma-separated steps to skip. Available: {', '.join(CONFIGURE_STEPS.keys())}.",
+        ),
+    ] = None,
 ) -> None:
     """Configure a new deployment instance."""
+    eff_steps = parse_step_option(steps)
+    eff_skip_steps = parse_step_option(skip_steps)
+    try:
+        validate_step_slugs("--steps", eff_steps, CONFIGURE_STEPS, allow_all=True)
+        validate_step_slugs("--except", eff_skip_steps, CONFIGURE_STEPS, allow_all=False)
+    except ValueError as exc:
+        typer.echo(typer.style(str(exc), fg="red"), err=True)
+        raise typer.Exit(code=1) from exc
+
+    def _run_step(slug: str) -> bool:
+        return ("all" in eff_steps or slug in eff_steps) and slug not in eff_skip_steps
+
     cfg = load_config(ctx.obj["config"], instance_name)
     try:
         opts = resolve_options(
@@ -107,131 +142,136 @@ def configure(  # noqa: C901
     service_path = f"{instance_path}/{eff_repo_subdir}" if eff_repo_subdir else instance_path
 
     # Step 2: Set up instance directory
-    if eff_type == "python" and eff_requirements:
-        # Package mode: create directory directly, no git clone
-        try:
-            executor.run(f"test -d {instance_path}")
-            if not force:
-                msg = f"Instance directory already exists: ~/{instance_name}\nUse --force to re-run setup."
-                typer.echo(typer.style(msg, fg="yellow"), err=True)
-                raise typer.Exit(code=1)
-            typer.secho("\nDirectory exists, skipping mkdir (--force).", fg="yellow")
-        except ExecutorError:
+    if _run_step("dir"):
+        if eff_type == "python" and eff_requirements:
+            # Package mode: create directory directly, no git clone
+            try:
+                executor.run(f"test -d {instance_path}")
+                if not force:
+                    msg = f"Instance directory already exists: ~/{instance_name}\nUse --force to re-run setup."
+                    typer.echo(typer.style(msg, fg="yellow"), err=True)
+                    raise typer.Exit(code=1)
+                typer.secho("\nDirectory exists, skipping mkdir (--force).", fg="yellow")
+            except ExecutorError:
+                typer.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
+                executor.run(f"mkdir -p {instance_path}")
+        elif eff_type == "service" and not eff_repo_url:
+            # Binary/system service mode: no repo, just ensure a working directory exists
             typer.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
             executor.run(f"mkdir -p {instance_path}")
-    elif eff_type == "service" and not eff_repo_url:
-        # Binary/system service mode: no repo, just ensure a working directory exists
-        typer.secho(f"\nCreating instance directory ~/{instance_name}…", fg="green")
-        executor.run(f"mkdir -p {instance_path}")
-    else:
-        if not eff_repo_url:
-            msg = "repo_url is required. Provide it as an argument or set it in deploy.yml."
-            typer.echo(typer.style(msg, fg="red"), err=True)
-            raise typer.Exit(code=1)
-
-        # Repo mode: clone
-        if _is_git_repo(executor, instance_path):
-            if not force:
-                msg = (
-                    f"Instance directory already exists: ~/{instance_name}\n"
-                    "Use --force to skip cloning and re-run setup."
-                )
-                typer.echo(typer.style(msg, fg="yellow"), err=True)
-                raise typer.Exit(code=1)
-            typer.secho("\nDirectory exists, skipping clone (--force).", fg="yellow")
         else:
-            typer.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
-            try:
-                clone_cmd = f"git clone --recurse-submodules {eff_repo_url} $HOME/{instance_name}"
-                if eff_repo_branch:
-                    clone_cmd += f" --branch {eff_repo_branch}"
-                executor.run(clone_cmd)
-            except ExecutorError as exc:
-                typer.echo(typer.style(f"Git clone failed: {exc}", fg="red"), err=True)
-                raise typer.Exit(code=1) from exc
+            if not eff_repo_url:
+                msg = "repo_url is required. Provide it as an argument or set it in deploy.yml."
+                typer.echo(typer.style(msg, fg="red"), err=True)
+                raise typer.Exit(code=1)
 
-    # Step 3: Ensure Postgres role and run gitaggregate if needed
-    if eff_type == "odoo":
+            # Repo mode: clone
+            if _is_git_repo(executor, instance_path):
+                if not force:
+                    msg = (
+                        f"Instance directory already exists: ~/{instance_name}\n"
+                        "Use --force to skip cloning and re-run setup."
+                    )
+                    typer.echo(typer.style(msg, fg="yellow"), err=True)
+                    raise typer.Exit(code=1)
+                typer.secho("\nDirectory exists, skipping clone (--force).", fg="yellow")
+            else:
+                typer.secho(f"\nCloning {eff_repo_url} into ~/{instance_name}…", fg="green")
+                try:
+                    clone_cmd = f"git clone --recurse-submodules {eff_repo_url} $HOME/{instance_name}"
+                    if eff_repo_branch:
+                        clone_cmd += f" --branch {eff_repo_branch}"
+                    executor.run(clone_cmd)
+                except ExecutorError as exc:
+                    typer.echo(typer.style(f"Git clone failed: {exc}", fg="red"), err=True)
+                    raise typer.Exit(code=1) from exc
+
+    # Step 3: Run gitaggregate if needed
+    if eff_type == "odoo" and _run_step("gitaggregate"):
+        executor.run(
+            "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
+            cwd=instance_path,
+        )
+
+    # Step 3b: Ensure Postgres role exists
+    if eff_type == "odoo" and _run_step("pg"):
         try:
             _ensure_postgres_user(executor, instance_name)
         except ExecutorError as exc:
             typer.echo(typer.style(str(exc), fg="red"), err=True)
             raise typer.Exit(code=1) from exc
 
-        executor.run(
-            "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
-            cwd=instance_path,
-        )
-
     # Step 4: Set up environment
-    typer.secho(f"\nSetting up {eff_type} environment…", fg="green")
-    try:
-        if eff_type == "odoo":
-            setup_odoo_venv(executor, instance_path, force=force)
-        elif eff_type == "python":
-            if eff_requirements:
-                setup_package_venv(executor, instance_path, eff_requirements, force=force)
-            else:
-                setup_python_venv(executor, service_path, force=force)
-                executor.run(
-                    "if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi",
-                    cwd=service_path,
-                )
-        else:  # service
-            build_cmd: str | None = opts.get("build")
-            if build_cmd:
-                executor.run(build_cmd, cwd=service_path)
-    except ExecutorError as exc:
-        typer.echo(typer.style(str(exc), fg="red"), err=True)
-        raise typer.Exit(code=1) from exc
+    if _run_step("venv"):
+        typer.secho(f"\nSetting up {eff_type} environment…", fg="green")
+        try:
+            if eff_type == "odoo":
+                setup_odoo_venv(executor, instance_path, force=force)
+            elif eff_type == "python":
+                if eff_requirements:
+                    setup_package_venv(executor, instance_path, eff_requirements, force=force)
+                else:
+                    setup_python_venv(executor, service_path, force=force)
+                    executor.run(
+                        "if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi",
+                        cwd=service_path,
+                    )
+            else:  # service
+                build_cmd: str | None = opts.get("build")
+                if build_cmd:
+                    executor.run(build_cmd, cwd=service_path)
+        except ExecutorError as exc:
+            typer.echo(typer.style(str(exc), fg="red"), err=True)
+            raise typer.Exit(code=1) from exc
 
     # Step 5: Install systemd unit
-    typer.secho("\nInstalling systemd unit…", fg="green")
-    unit_instance_path = instance_path if eff_requirements else service_path
-    venv_path = f"{unit_instance_path}/.venv"
+    if _run_step("unit"):
+        typer.secho(f"\n{CONFIGURE_STEPS['unit']}…", fg="green")
+        unit_instance_path = instance_path if eff_requirements else service_path
+        venv_path = f"{unit_instance_path}/.venv"
 
-    template_vars: dict[str, Any] = {
-        "instance_name": instance_name,
-        "instance_path": unit_instance_path,
-    }
-    if eff_type == "odoo":
-        template_vars["venv_path"] = venv_path
-        odoo_addons_path = executor.capture("which odoo-addons-path")
-        template_vars["odoo_addons_path"] = odoo_addons_path
-    else:
-        exec_start: str = opts.get("exec_start", "")
-        if not exec_start and not eff_requirements:
-            res = executor.capture(
-                "if [ -f server.py ]; then echo server.py; fi",
-                cwd=service_path,
-            )
-            if res == "server.py":
-                exec_start = "python server.py"
-        if not exec_start:
-            msg = "exec_start is required for service or python type. Set it in deploy.yml."
-            typer.echo(typer.style(msg, fg="red"), err=True)
-            raise typer.Exit(code=1)
-        if eff_type == "python":
+        template_vars: dict[str, Any] = {
+            "instance_name": instance_name,
+            "instance_path": unit_instance_path,
+        }
+        if eff_type == "odoo":
             template_vars["venv_path"] = venv_path
-        template_vars["exec_start"] = exec_start
+            odoo_addons_path = executor.capture("which odoo-addons-path")
+            template_vars["odoo_addons_path"] = odoo_addons_path
+        else:
+            exec_start: str = opts.get("exec_start", "")
+            if not exec_start and not eff_requirements:
+                res = executor.capture(
+                    "if [ -f server.py ]; then echo server.py; fi",
+                    cwd=service_path,
+                )
+                if res == "server.py":
+                    exec_start = "python server.py"
+            if not exec_start:
+                msg = "exec_start is required for service or python type. Set it in deploy.yml."
+                typer.echo(typer.style(msg, fg="red"), err=True)
+                raise typer.Exit(code=1)
+            if eff_type == "python":
+                template_vars["venv_path"] = venv_path
+            template_vars["exec_start"] = exec_start
 
-    try:
-        unit_content = render_unit(eff_type, **template_vars)
-    except Exception as exc:
-        typer.echo(typer.style(f"Template rendering failed: {exc}", fg="red"), err=True)
-        raise typer.Exit(code=1) from exc
+        try:
+            unit_content = render_unit(eff_type, **template_vars)
+        except Exception as exc:
+            typer.echo(typer.style(f"Template rendering failed: {exc}", fg="red"), err=True)
+            raise typer.Exit(code=1) from exc
 
-    unit_dir = "$HOME/.config/systemd/user"
-    unit_path = f"{unit_dir}/{instance_name}.service"
-    try:
-        executor.run(f"mkdir -p {unit_dir}")
-        executor.write_file(unit_content, unit_path)
-        executor.run("loginctl enable-linger")
-        executor.run("systemctl --user daemon-reload")
-        executor.run(f"systemctl --user enable --now {instance_name}")
-    except ExecutorError as exc:
-        typer.echo(typer.style(str(exc), fg="red"), err=True)
-        raise typer.Exit(code=1) from exc
+        unit_dir = "$HOME/.config/systemd/user"
+        unit_path = f"{unit_dir}/{instance_name}.service"
+        try:
+            executor.run(f"mkdir -p {unit_dir}")
+            executor.write_file(unit_content, unit_path)
+            executor.run("loginctl enable-linger")
+            executor.run("systemctl --user daemon-reload")
+            executor.run(f"systemctl --user enable --now {instance_name}")
+        except ExecutorError as exc:
+            typer.echo(typer.style(str(exc), fg="red"), err=True)
+            raise typer.Exit(code=1) from exc
 
     typer.secho(f"\nInstance {instance_name!r} configured successfully.", fg="green")
 

--- a/trobz_deploy/command/restart.py
+++ b/trobz_deploy/command/restart.py
@@ -19,7 +19,13 @@ def restart(
     ssh_port: Annotated[int | None, typer.Option("-p", "--port", help="SSH port on the remote host.")] = None,
     watch: Annotated[
         bool,
-        typer.Option("--watch", help="Stream service logs with journalctl after restarting."),
+        typer.Option(
+            "--watch",
+            help=(
+                "Stream service logs with journalctl after restarting. "
+                "Also merge with odoo and click-odoo-update logs if applicable."
+            ),
+        ),
     ] = False,
 ) -> None:
     """Restart the systemd unit for a deployment instance."""

--- a/trobz_deploy/command/status.py
+++ b/trobz_deploy/command/status.py
@@ -49,7 +49,13 @@ def status(
     ssh_port: Annotated[int | None, typer.Option("-p", "--port", help="SSH port on the remote host.")] = None,
     watch: Annotated[
         bool,
-        typer.Option("--watch", help="Stream service logs with journalctl after showing status."),
+        typer.Option(
+            "--watch",
+            help=(
+                "Stream service logs with journalctl after showing status. "
+                "Also merge with odoo and click-odoo-update logs if applicable."
+            ),
+        ),
     ] = False,
 ) -> None:
     """Show status of a deployment instance."""

--- a/trobz_deploy/command/update.py
+++ b/trobz_deploy/command/update.py
@@ -42,7 +42,13 @@ def update(  # noqa: C901
     ] = None,
     watch: Annotated[
         bool,
-        typer.Option("--watch", help="Stream service logs with journalctl after a successful update."),
+        typer.Option(
+            "--watch",
+            help=(
+                "Stream service logs with journalctl after a successful update. "
+                "Also merge with odoo and click-odoo-update logs if applicable."
+            ),
+        ),
     ] = False,
     steps: Annotated[
         str,

--- a/trobz_deploy/command/update.py
+++ b/trobz_deploy/command/update.py
@@ -5,9 +5,15 @@ from typing import Annotated
 import typer
 
 from trobz_deploy.utils.addons import get_addons_path
-from trobz_deploy.utils.config import DeployType, load_config, resolve_options
+from trobz_deploy.utils.config import DeployType, load_config, parse_step_option, resolve_options, validate_step_slugs
 from trobz_deploy.utils.executor import Executor, ExecutorError
 from trobz_deploy.utils.venv import setup_python_deps, upgrade_package
+
+UPDATE_STEPS = {
+    "pull": "Pulling latest code",
+    "venv": "Updating dependencies in venv",
+    "db": "Updating database(s)",
+}
 
 
 def update(  # noqa: C901
@@ -38,8 +44,34 @@ def update(  # noqa: C901
         bool,
         typer.Option("--watch", help="Stream service logs with journalctl after a successful update."),
     ] = False,
+    steps: Annotated[
+        str,
+        typer.Option(
+            "--steps",
+            help=f"Comma-separated steps to run, or 'all'. Available: {', '.join(UPDATE_STEPS.keys())}.",
+        ),
+    ] = "all",
+    skip_steps: Annotated[
+        str | None,
+        typer.Option(
+            "--except",
+            help=f"Comma-separated steps to skip. Available: {', '.join(UPDATE_STEPS.keys())}.",
+        ),
+    ] = None,
 ) -> None:
     """Update an existing deployment instance."""
+    eff_steps = parse_step_option(steps)
+    eff_skip_steps = parse_step_option(skip_steps)
+    try:
+        validate_step_slugs("--steps", eff_steps, UPDATE_STEPS, allow_all=True)
+        validate_step_slugs("--except", eff_skip_steps, UPDATE_STEPS, allow_all=False)
+    except ValueError as exc:
+        typer.echo(typer.style(str(exc), fg="red"), err=True)
+        raise typer.Exit(code=1) from exc
+
+    def _run_step(slug: str) -> bool:
+        return ("all" in eff_steps or slug in eff_steps) and slug not in eff_skip_steps
+
     cfg = load_config(ctx.obj["config"], instance_name)
     try:
         opts = resolve_options(
@@ -106,65 +138,68 @@ def update(  # noqa: C901
     # Step 5+6: Pull/upgrade code and update dependencies
     if eff_type == "python" and eff_requirements:
         # Package mode: upgrade pip package directly, no git pull
-        typer.secho("\nUpgrading package…", fg="green")
-        try:
-            upgrade_package(executor, instance_path, eff_requirements)
-        except ExecutorError as exc:
-            run_hooks("post-update")
-            run_hooks("post-update-fail")
-            typer.echo(typer.style(f"Package upgrade failed: {exc}", fg="red"), err=True)
-            raise typer.Exit(code=1) from exc
+        if _run_step("venv"):
+            typer.secho(f"\n{UPDATE_STEPS['venv']}…", fg="green")
+            try:
+                upgrade_package(executor, instance_path, eff_requirements)
+            except ExecutorError as exc:
+                run_hooks("post-update")
+                run_hooks("post-update-fail")
+                typer.echo(typer.style(f"Package upgrade failed: {exc}", fg="red"), err=True)
+                raise typer.Exit(code=1) from exc
     elif eff_type == "service" and not opts.get("repo_url"):
         # Binary/system service mode: no repo to pull, skip straight to restart
-        typer.secho("\nNo repository to update, skipping pull…", fg="yellow")
+        if _run_step("pull"):
+            typer.secho("\nNo repository to update, skipping pull…", fg="yellow")
     else:
-        # Repo mode: git pull then update deps
-        try:
-            executor.run(f"test -d {instance_path}/.git")
-        except ExecutorError:
-            msg = f"Instance directory not found or not a git repo: ~/{instance_name}"
-            typer.echo(typer.style(msg, fg="red"), err=True)
-            raise typer.Exit(code=1) from None
+        # Repo mode: git pull then update venv
+        if _run_step("pull"):
+            try:
+                executor.run(f"test -d {instance_path}/.git")
+            except ExecutorError:
+                msg = f"Instance directory not found or not a git repo: ~/{instance_name}"
+                typer.echo(typer.style(msg, fg="red"), err=True)
+                raise typer.Exit(code=1) from None
 
-        typer.secho("\nPulling latest code…", fg="green")
-        try:
-            if eff_repo_branch:
-                executor.run(
-                    f"git fetch origin && git checkout {eff_repo_branch} && git pull --recurse-submodules",
-                    cwd=instance_path,
-                )
-            else:
-                executor.run("git pull --recurse-submodules", cwd=instance_path)
-        except ExecutorError as exc:
-            run_hooks("post-update")
-            run_hooks("post-update-fail")
-            typer.echo(typer.style(f"git pull failed: {exc}", fg="red"), err=True)
-            raise typer.Exit(code=1) from exc
+            typer.secho(f"\n{UPDATE_STEPS['pull']}…", fg="green")
+            try:
+                if eff_repo_branch:
+                    executor.run(
+                        f"git fetch origin && git checkout {eff_repo_branch} && git pull --recurse-submodules",
+                        cwd=instance_path,
+                    )
+                else:
+                    executor.run("git pull --recurse-submodules", cwd=instance_path)
+            except ExecutorError as exc:
+                run_hooks("post-update")
+                run_hooks("post-update-fail")
+                typer.echo(typer.style(f"git pull failed: {exc}", fg="red"), err=True)
+                raise typer.Exit(code=1) from exc
 
-        typer.secho("\nUpdating dependencies…", fg="green")
-        try:
-            if eff_type == "odoo":
-                executor.run(
-                    "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
-                    cwd=instance_path,
-                )
-                executor.run("odoo-venv update .venv --backup --yes", cwd=instance_path)
-            elif eff_type == "python":
-                setup_python_deps(executor, service_path)
-            else:  # service
-                build_cmd: str | None = opts.get("build")
-                if build_cmd:
-                    executor.run(build_cmd, cwd=service_path)
-        except ExecutorError as exc:
-            run_hooks("post-update")
-            run_hooks("post-update-fail")
-            typer.echo(typer.style(f"Dependency update failed: {exc}", fg="red"), err=True)
-            raise typer.Exit(code=1) from exc
+        if _run_step("venv"):
+            typer.secho(f"\n{UPDATE_STEPS['venv']}…", fg="green")
+            try:
+                if eff_type == "odoo":
+                    executor.run(
+                        "if [ -f addons/repos.yaml ]; then cd addons/ && gitaggregate -c repos.yaml; fi",
+                        cwd=instance_path,
+                    )
+                    executor.run("odoo-venv update .venv --backup --yes", cwd=instance_path)
+                elif eff_type == "python":
+                    setup_python_deps(executor, service_path)
+                else:  # service
+                    build_cmd: str | None = opts.get("build")
+                    if build_cmd:
+                        executor.run(build_cmd, cwd=service_path)
+            except ExecutorError as exc:
+                run_hooks("post-update")
+                run_hooks("post-update-fail")
+                typer.echo(typer.style(f"Dependency update failed: {exc}", fg="red"), err=True)
+                raise typer.Exit(code=1) from exc
 
-    # Step 7: Apply changes
-    typer.secho("\nApplying changes…", fg="green")
-    try:
-        if eff_type == "odoo":
+    # Step 7: Update database (Odoo only)
+    if eff_type == "odoo" and _run_step("db"):
+        try:
             addons_path = get_addons_path(executor, instance_path)
             for db in eff_db:
                 typer.secho(f"\nUpdating database {db!r}…", fg="green")
@@ -173,11 +208,20 @@ def update(  # noqa: C901
                     f" --addons-path={addons_path} --logfile log/upgrade.log",
                     cwd=instance_path,
                 )
+        except ExecutorError as exc:
+            run_hooks("post-update")
+            run_hooks("post-update-fail")
+            typer.echo(typer.style(f"Database update failed: {exc}", fg="red"), err=True)
+            raise typer.Exit(code=1) from exc
+
+    # Step 8: Restart service to apply changes
+    typer.secho("\nApplying changes…", fg="green")
+    try:
         executor.run(f"systemctl --user restart {instance_name}")
     except ExecutorError as exc:
         run_hooks("post-update")
         run_hooks("post-update-fail")
-        typer.echo(typer.style(f"Restart/upgrade failed: {exc}", fg="red"), err=True)
+        typer.echo(typer.style(f"Restart failed: {exc}", fg="red"), err=True)
         raise typer.Exit(code=1) from exc
 
     # Step 8: post-update hooks

--- a/trobz_deploy/utils/config.py
+++ b/trobz_deploy/utils/config.py
@@ -118,3 +118,20 @@ def resolve_options(
         resolved["db"] = instance_name
 
     return resolved
+
+
+def parse_step_option(value: str | None) -> list[str]:
+    """Split a comma-separated option value into a list of trimmed, non-empty slugs."""
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def validate_step_slugs(option_name: str, slugs: list[str], valid_steps: dict[str, str], *, allow_all: bool) -> None:
+    """Raise ValueError if any of *slugs* is not in *valid_steps* (or 'all' when allowed)."""
+    valid = {*valid_steps, "all"} if allow_all else set(valid_steps)
+    invalid = sorted(set(slugs) - valid)
+    if invalid:
+        choices = ", ".join((*valid_steps, "all") if allow_all else valid_steps)
+        msg = f"Invalid {option_name} value(s): {', '.join(invalid)}. Available steps: {choices}"
+        raise ValueError(msg)

--- a/trobz_deploy/utils/venv.py
+++ b/trobz_deploy/utils/venv.py
@@ -13,10 +13,10 @@ def _venv_exists(executor: Executor, instance_path: str) -> bool:
     return True
 
 
-def setup_odoo_venv(executor: Executor, instance_path: str, force: bool = False) -> None:
+def setup_odoo_venv(executor: Executor, instance_path: str) -> None:
     """Create or update an Odoo virtual environment using ``odoo-venv``."""
-    if force and _venv_exists(executor, instance_path):
-        typer.secho("Venv exists, skipping venv creation (--force).", fg="yellow")
+    if _venv_exists(executor, instance_path):
+        typer.secho("Venv exists, skipping venv creation. Use --except venv to skip this step.", fg="yellow")
         return
     executor.run(
         f"odoo-venv create --project-dir {instance_path} --preset project",
@@ -24,10 +24,10 @@ def setup_odoo_venv(executor: Executor, instance_path: str, force: bool = False)
     )
 
 
-def setup_python_venv(executor: Executor, instance_path: str, force: bool = False) -> None:
+def setup_python_venv(executor: Executor, instance_path: str) -> None:
     """Create a venv with ``uv`` and install dependencies from requirements.txt."""
-    if force and _venv_exists(executor, instance_path):
-        typer.secho("Venv exists, skipping venv creation (--force).", fg="yellow")
+    if _venv_exists(executor, instance_path):
+        typer.secho("Venv exists, skipping venv creation. Use --except venv to skip this step.", fg="yellow")
     else:
         executor.run("uv venv .venv", cwd=instance_path)
     setup_python_deps(executor, instance_path)
@@ -38,10 +38,10 @@ def setup_python_deps(executor: Executor, instance_path: str) -> None:
     executor.run("if [ -e pyproject.toml ]; then uv sync; fi", cwd=instance_path)
 
 
-def setup_package_venv(executor: Executor, instance_path: str, requirements: list[str], force: bool = False) -> None:
+def setup_package_venv(executor: Executor, instance_path: str, requirements: list[str]) -> None:
     """Create a venv with ``uv`` and install pip packages directly."""
-    if force and _venv_exists(executor, instance_path):
-        typer.secho("Venv exists, skipping venv creation (--force).", fg="yellow")
+    if _venv_exists(executor, instance_path):
+        typer.secho("Venv exists, skipping venv creation. Use --except venv to skip this step.", fg="yellow")
     else:
         executor.run("uv venv .venv", cwd=instance_path)
     executor.run(f"uv pip install {' '.join(requirements)}", cwd=instance_path)


### PR DESCRIPTION
Allow running or skipping individual steps in `configure` and `update`
via comma-separated --step/--except options (or 'all'). Shared parsing
and validation helpers (parse_step_option, validate_step_slugs) moved to
utils/config.py.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Forge ID: F#T67933

Imply PR https://github.com/trobz/deploy.py/pull/37